### PR TITLE
Add `module` and `warn` arguments

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -12,7 +12,8 @@ var compile    = require("node-elm-compiler").compile,
   util         = require("util"),
   _            = require("lodash"),
   spawn        = require("cross-spawn"),
-  minimist     = require("minimist");
+  minimist     = require("minimist"),
+  firstline    = require("firstline");
 
 var elm = {
   'elm-package': 'elm-package'
@@ -24,15 +25,12 @@ var args = minimist(process.argv.slice(2), {
         'compiler': 'c'
     },
     boolean: [ 'yes', 'warn', 'version', 'help' ],
-    string: [ 'compiler', 'module' ],
-    default: {
-        'module': 'Main'
-    }
+    string: [ 'compiler' ]
 });
 
 if (args.help) {
   console.log("Usage: elm-test init [--yes]  # Create example tests\n");
-  console.log("Usage: elm-test TESTFILE [--compiler /path/to/compiler] [--module Tests.MyTestRunner] # Run TESTFILE\n");
+  console.log("Usage: elm-test TESTFILE [--compiler /path/to/compiler] # Run TESTFILE\n");
   console.log("Usage: elm-test [--compiler /path/to/compiler] # Run tests/Main.elm\n");
   process.exit(1);
 }
@@ -81,7 +79,7 @@ if (args._[0] == "init") {
   process.exit(0);
 }
 
-function evalElmCode (compiledCode) {
+function evalElmCode (compiledCode, testModuleName) {
   var Elm = function(module) { eval(compiledCode); return module.exports; }({});
 
   // Make sure necessary things are defined.
@@ -89,7 +87,7 @@ function evalElmCode (compiledCode) {
 
   function getTestModule() {
       var module = Elm;
-      var moduleParts = args.module.split('.');
+      var moduleParts = testModuleName.split('.');
       while (moduleParts.length) {
           var modulePart = moduleParts.shift();
           if (module[modulePart] === undefined) {
@@ -103,7 +101,7 @@ function evalElmCode (compiledCode) {
   }
 
   var testModule = getTestModule();
-  if (testModule === undefined) { throw 'Elm.' + args.module + ' is not defined. Make sure your module is named Main, or pass the module via the --module option.' };
+  if (testModule === undefined) { throw 'Elm.' + testModuleName + ' is not defined. Make sure you provide a file compiled by Elm!' };
 
   // Apply Node polyfills as necessary.
   var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
@@ -197,6 +195,8 @@ temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
       process.exit(exitCode);
     }
 
-    evalElmCode(fs.readFileSync(dest, {encoding: "utf8"}));
+    testModulePromise.then(function (testModuleName) {
+        evalElmCode(fs.readFileSync(dest, {encoding: "utf8"}), testModuleName);
+    });
   });
 });

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -23,7 +23,7 @@ var args = minimist(process.argv.slice(2), {
         'yes': 'y',
         'compiler': 'c'
     },
-    boolean: [ 'yes', 'version', 'help' ],
+    boolean: [ 'yes', 'warn', 'version', 'help' ],
     string: [ 'compiler' ]
 });
 
@@ -169,7 +169,7 @@ if (args.compiler !== undefined) {
 temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
   var dest = info.path;
   var compileProcess = compile( [testFile],
-    {output: dest, spawn: spawnCompiler, pathToMake: pathToMake});
+    {output: dest, spawn: spawnCompiler, pathToMake: pathToMake, warn:args.warn});
 
   compileProcess.on('close', function(exitCode) {
     if (exitCode !== 0) {

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -86,7 +86,24 @@ function evalElmCode (compiledCode) {
 
   // Make sure necessary things are defined.
   if (typeof Elm === 'undefined') { throw 'elm-io config error: Elm is not defined. Make sure you provide a file compiled by Elm!'}
-  if (typeof Elm[args.module] === 'undefined' ) { throw 'Elm.' + args.module + ' is not defined. Make sure your module is named Main, or pass the module via the --module option.' };
+
+  function getTestModule() {
+      var module = Elm;
+      var moduleParts = args.module.split('.');
+      while (moduleParts.length) {
+          var modulePart = moduleParts.shift();
+          if (module[modulePart] === undefined) {
+              return undefined;
+          }
+
+          module = module[modulePart];
+      }
+
+      return module;
+  }
+
+  var testModule = getTestModule();
+  if (testModule === undefined) { throw 'Elm.' + args.module + ' is not defined. Make sure your module is named Main, or pass the module via the --module option.' };
 
   // Apply Node polyfills as necessary.
   var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
@@ -120,7 +137,7 @@ function evalElmCode (compiledCode) {
   }
 
   // Run the Elm app.
-  var app = Elm[args.module].worker();
+  var app = testModule.worker();
 
   // Receive messages from ports and translate them into appropriate JS calls.
   app.ports.emit.subscribe(function(msg) {

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -24,12 +24,15 @@ var args = minimist(process.argv.slice(2), {
         'compiler': 'c'
     },
     boolean: [ 'yes', 'warn', 'version', 'help' ],
-    string: [ 'compiler' ]
+    string: [ 'compiler', 'module' ],
+    default: {
+        'module': 'Main'
+    }
 });
 
 if (args.help) {
   console.log("Usage: elm-test init [--yes]  # Create example tests\n");
-  console.log("Usage: elm-test TESTFILE [--compiler /path/to/compiler] # Run TESTFILE\n");
+  console.log("Usage: elm-test TESTFILE [--compiler /path/to/compiler] [--module Tests.MyTestRunner] # Run TESTFILE\n");
   console.log("Usage: elm-test [--compiler /path/to/compiler] # Run tests/Main.elm\n");
   process.exit(1);
 }
@@ -83,7 +86,7 @@ function evalElmCode (compiledCode) {
 
   // Make sure necessary things are defined.
   if (typeof Elm === 'undefined') { throw 'elm-io config error: Elm is not defined. Make sure you provide a file compiled by Elm!'}
-  if (typeof Elm.Main === 'undefined' ) { throw 'Elm.Main is not defined. Make sure your module is named Main.' };
+  if (typeof Elm[args.module] === 'undefined' ) { throw 'Elm.' + args.module + ' is not defined. Make sure your module is named Main, or pass the module via the --module option.' };
 
   // Apply Node polyfills as necessary.
   var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
@@ -117,7 +120,7 @@ function evalElmCode (compiledCode) {
   }
 
   // Run the Elm app.
-  var app = Elm.Main.worker();
+  var app = Elm[args.module].worker();
 
   // Receive messages from ports and translate them into appropriate JS calls.
   app.ports.emit.subscribe(function(msg) {

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -11,25 +11,35 @@ var compile    = require("node-elm-compiler").compile,
   temp         = require("temp").track(), // Automatically cleans up temp files.
   util         = require("util"),
   _            = require("lodash"),
-  spawn        = require("cross-spawn");
+  spawn        = require("cross-spawn"),
+  minimist     = require("minimist");
 
 var elm = {
   'elm-package': 'elm-package'
 };
+var args = minimist(process.argv.slice(2), {
+    alias: {
+        'help': 'h',
+        'yes': 'y',
+        'compiler': 'c'
+    },
+    boolean: [ 'yes', 'version', 'help' ],
+    string: [ 'compiler' ]
+});
 
-if (process.argv[2] == "--help" || process.argv[2] == "-h") {
+if (args.help) {
   console.log("Usage: elm-test init [--yes]  # Create example tests\n");
   console.log("Usage: elm-test TESTFILE [--compiler /path/to/compiler] # Run TESTFILE\n");
   console.log("Usage: elm-test [--compiler /path/to/compiler] # Run tests/Main.elm\n");
   process.exit(1);
 }
 
-if (process.argv[2] == "--version") {
+if (args.version) {
   console.log(require(path.join(__dirname, "..", "package.json")).version);
   process.exit(0);
 }
 
-if (process.argv[2] == "init") {
+if (args._[0] == "init") {
   var copyTemplate = function(templateName, destName) {
     if (arguments.length == 1) {
       destName = templateName;
@@ -55,7 +65,7 @@ if (process.argv[2] == "init") {
   };
 
   var elmOptions = "";
-  if (process.argv[3] == "--yes" || process.argv[3] == "-y") {
+  if (args.yes) {
     elmOptions += " --yes";
   }
 
@@ -123,7 +133,7 @@ function evalElmCode (compiledCode) {
   });
 }
 
-var testFile = process.argv[2],
+var testFile = args._[0],
     cwd = __dirname,
     pathToMake = undefined;
 
@@ -147,8 +157,8 @@ if (testFile.slice(0, 6) == "tests/") {
   testFile = testFile.slice(6);
 }
 
-if (process.argv[3] == "--compiler" || process.argv[3] == "-c") {
-  pathToMake = process.argv[4];
+if (args.compiler !== undefined) {
+  pathToMake = args.compiler;
 
   if (!pathToMake) {
     console.error("The --compiler option must be given a path to an elm-make executable.");

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cross-spawn": "4.0.0",
     "fs-extra": "0.30.0",
     "lodash": "4.13.1",
+    "minimist": "^1.2.0",
     "node-elm-compiler": "4.1.0",
     "temp": "0.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "chalk": "1.1.3",
     "cross-spawn": "4.0.0",
+    "firstline": "^1.2.0",
     "fs-extra": "0.30.0",
     "lodash": "4.13.1",
     "minimist": "^1.2.0",


### PR DESCRIPTION
This updates the command line parsing to use minimist (per the recommendation on #38).  It then adds a pass-through for `--warn`, and adds the ability to pass the module name of the test module.

This fixes #54, as well as fixing #38