### PR TITLE
Find elm-package.json automatically

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -13,7 +13,8 @@ var compile    = require("node-elm-compiler").compile,
   _            = require("lodash"),
   spawn        = require("cross-spawn"),
   minimist     = require("minimist"),
-  firstline    = require("firstline");
+  firstline    = require("firstline"),
+  findUp       = require("find-up");
 
 var elm = {
   'elm-package': 'elm-package'
@@ -165,16 +166,6 @@ if (typeof testFile == "undefined") {
   testFile = "tests/Main.elm";
 }
 
-if (!fs.existsSync(testFile)) {
-  console.error("Could not find file " + testFile);
-  process.exit(1);
-}
-
-if (testFile.slice(0, 6) == "tests/") {
-  process.chdir("./tests");
-  testFile = testFile.slice(6);
-}
-
 if (args.compiler !== undefined) {
   pathToMake = args.compiler;
 
@@ -184,19 +175,42 @@ if (args.compiler !== undefined) {
   }
 }
 
-temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
-  var dest = info.path;
-  var compileProcess = compile( [testFile],
-    {output: dest, spawn: spawnCompiler, pathToMake: pathToMake, warn:args.warn});
+if (!fs.existsSync(testFile)) {
+  console.error("Could not find file " + testFile);
+  process.exit(1);
+}
 
-  compileProcess.on('close', function(exitCode) {
-    if (exitCode !== 0) {
-      console.error("Compilation failed for", testFile);
-      process.exit(exitCode);
+var testModulePromise = firstline(testFile).then(function (testModuleLine) {
+    var moduleMatches = testModuleLine.match(/^(?:port\s+)?module\s+([^\s]+)/);
+    if (moduleMatches) {
+        return moduleMatches[1];
     }
 
-    testModulePromise.then(function (testModuleName) {
-        evalElmCode(fs.readFileSync(dest, {encoding: "utf8"}), testModuleName);
-    });
-  });
+    return 'Main';
+});
+
+findUp('elm-package.json', { cwd: path.dirname(testFile) })
+    .then(function (elmPackagePath) {
+        var elmRootDir = path.dirname(elmPackagePath);
+        if (fs.realpathSync(elmRootDir) !== fs.realpathSync(process.cwd())) {
+            testFile = path.relative(elmRootDir, testFile);
+            process.chdir(elmRootDir);
+        }
+
+        temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
+            var dest = info.path;
+            var compileProcess = compile( [testFile],
+                {output: dest, spawn: spawnCompiler, pathToMake: pathToMake, warn:args.warn});
+
+            compileProcess.on('close', function(exitCode) {
+                if (exitCode !== 0) {
+                    console.error("Compilation failed for", testFile);
+                    process.exit(exitCode);
+                }
+
+                testModulePromise.then(function (testModuleName) {
+                    evalElmCode(fs.readFileSync(dest, {encoding: "utf8"}), testModuleName);
+                });
+            });
+        });
 });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "chalk": "1.1.3",
     "cross-spawn": "4.0.0",
+    "find-up": "^1.1.2",
     "firstline": "^1.2.0",
     "fs-extra": "0.30.0",
     "lodash": "4.13.1",


### PR DESCRIPTION
I noticed that the code was hard-coded to look for `tests/` (which I also noticed because it didn't work on Windows because of the different slash), and thought that it would be better to find `elm-package.json` instead.

Fixes #59 
