### PR TITLE
Accept initial seed as a CLI argument.

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -23,16 +23,18 @@ var args = minimist(process.argv.slice(2), {
     alias: {
         'help': 'h',
         'yes': 'y',
+        'seed': 's',
         'compiler': 'c'
     },
     boolean: [ 'yes', 'warn', 'version', 'help' ],
-    string: [ 'compiler' ]
+    string: [ 'compiler', 'seed' ]
 });
 
 if (args.help) {
   console.log("Usage: elm-test init [--yes]  # Create example tests\n");
   console.log("Usage: elm-test TESTFILE [--compiler /path/to/compiler] # Run TESTFILE\n");
   console.log("Usage: elm-test [--compiler /path/to/compiler] # Run tests/Main.elm\n");
+  console.log("Usage: elm-test [--seed integer] # Run with initial fuzzer seed\n");
   process.exit(1);
 }
 
@@ -104,9 +106,16 @@ function evalElmCode (compiledCode, testModuleName) {
   var testModule = getTestModule();
   if (testModule === undefined) { throw 'Elm.' + testModuleName + ' is not defined. Make sure you provide a file compiled by Elm!' };
 
+  var initialSeed = null;
+
+  if (args.seed !== undefined) {
+    initialSeed = args.seed;
+  }
+
   // Apply Node polyfills as necessary.
   var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
   var document = {body: {}, createTextNode: function() {}};
+  pathToMake = args.compiler;
   if (typeof XMLHttpRequest === 'undefined') { XMLHttpRequest = function() { return { addEventListener: function() {}, open: function() {}, send: function() {} }; }; }
   if (typeof FormData === 'undefined') { FormData = function () { this._data = []; }; FormData.prototype.append = function () { this._data.push(Array.prototype.slice.call(arguments)); }; }
 
@@ -136,7 +145,7 @@ function evalElmCode (compiledCode, testModuleName) {
   }
 
   // Run the Elm app.
-  var app = testModule.worker();
+  var app = testModule.worker(initialSeed);
 
   // Receive messages from ports and translate them into appropriate JS calls.
   app.ports.emit.subscribe(function(msg) {

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,6 +11,7 @@
     ],
     "dependencies": {
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
         "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0"

--- a/examples/tests/FailingTests.elm
+++ b/examples/tests/FailingTests.elm
@@ -9,7 +9,7 @@ import Json.Encode exposing (Value)
 import Char
 
 
-main : Program Never
+main : Program Value
 main =
     [ testWithoutNums
     , testOxfordify

--- a/examples/tests/PassingTests.elm
+++ b/examples/tests/PassingTests.elm
@@ -6,7 +6,7 @@ import Test exposing (..)
 import Json.Encode exposing (Value)
 
 
-main : Program Never
+main : Program Value
 main =
     [ plainExpectation ]
         |> concat

--- a/examples/tests/elm-package.json
+++ b/examples/tests/elm-package.json
@@ -10,6 +10,7 @@
     "exposed-modules": [],
     "dependencies": {
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
         "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0"

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -248,9 +248,9 @@ reportBegin emit { testCount, initialSeed } =
     chalkWith emit <|
         [ { styles = []
           , text =
-                "Running "
+                "\nelm-test\n--------\n\nRunning "
                     ++ pluralize "test" "tests" testCount
-                    ++ ". To reproduce these results: elm-test --seed "
+                    ++ ". To reproduce these results, run: elm-test --seed "
                     ++ toString initialSeed
                     ++ "\n"
           }

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -250,7 +250,7 @@ reportBegin emit { testCount, initialSeed } =
           , text =
                 "Running "
                     ++ pluralize "test" "tests" testCount
-                    ++ " with fuzzer seed "
+                    ++ ". To reproduce these results: elm-test --seed "
                     ++ toString initialSeed
                     ++ "\n"
           }

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -289,7 +289,7 @@ type alias Emitter msg =
 Fuzz tests use a default run count of 100, and an initial seed based on the
 system time when the test runs begin.
 -}
-run : Emitter Msg -> Test -> Program Never
+run : Emitter Msg -> Test -> Program Value
 run =
     runWithOptions defaultOptions
 
@@ -314,7 +314,7 @@ type alias Options =
 {-| Run the test using the provided options. If `Nothing` is provided for either
 `runs` or `seed`, it will fall back on the options used in [`run`](#run).
 -}
-runWithOptions : Options -> Emitter Msg -> Test -> Program Never
+runWithOptions : Options -> Emitter Msg -> Test -> Program Value
 runWithOptions { runs, seed } emit =
     Test.Runner.Node.App.run
         { runs = runs

--- a/templates/Main.elm
+++ b/templates/Main.elm
@@ -5,7 +5,7 @@ import Test.Runner.Node exposing (run)
 import Json.Encode exposing (Value)
 
 
-main : Program Never
+main : Program Value
 main =
     run emit Tests.all
 


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/node-test-runner/issues/50 and https://github.com/rtfeldman/node-test-runner/issues/32

<img width="784" alt="screen shot 2016-08-17 at 5 38 18 pm" src="https://cloud.githubusercontent.com/assets/1094080/17758117/68adce96-64a1-11e6-9330-202736f04f38.png">

TODO:

- [ ] Update README
- [ ] Change `run` to calmly print errors and send a nonzero exit code instead of using `Debug.crash`