### PR TITLE
Init test fix

### DIFF
--- a/tests/ci.js
+++ b/tests/ci.js
@@ -1,81 +1,81 @@
 #!/usr/bin/env node
 
-require('shelljs/global')
+require('shelljs/global');
 
-var filename = __filename.replace(__dirname + '/', '')
+var filename = __filename.replace(__dirname + '/', '');
 
 function run(testFile) {
-  var logFile = 'elm-test.test.log'
-  var retVal
+  var logFile = 'elm-test.test.log';
+  var retVal;
 
   if (!testFile) {
-    retVal = exec('elm-test')
+    retVal = exec('elm-test');
   } else {
-    logFile = testFile + '.test.log'
-    retVal = exec('elm-test ' + testFile)
+    logFile = testFile + '.test.log';
+    retVal = exec('elm-test ' + testFile);
   }
 
-  retVal.toEnd(logFile)
-  return retVal.code
+  retVal.toEnd(logFile);
+  return retVal.code;
 }
 
 function assertTestFailure(testFile) {
-  var code = run(testFile)
+  var code = run(testFile);
   if (code !== 1) {
-    exec('echo ' + filename + ': ERROR: ' + (testFile ? testFile + ': ' : '') + 'Expected tests to fail >&2')
-    exit(1)
+    exec('echo ' + filename + ': ERROR: ' + (testFile ? testFile + ': ' : '') + 'Expected tests to fail >&2');
+    exit(1);
   }
 }
 
 function assertTestSuccess(testFile) {
-  var code = run(testFile)
+  var code = run(testFile);
   if (code !== 0) {
-    exec('echo ' + filename + ': ERROR: ' + (testFile ? testFile + ': ' : '') + 'Expected tests to pass >&2')
-    exit(1)
+    exec('echo ' + filename + ': ERROR: ' + (testFile ? testFile + ': ' : '') + 'Expected tests to pass >&2');
+    exit(1);
   }
 }
 
-echo(filename + ': Installing elm-test...')
-exec('npm install --global')
+echo(filename + ': Installing elm-test...');
+exec('npm install --global');
 
-echo(filename + ': Verifying installed elm-test version...')
-exec('elm-test --version')
+echo(filename + ': Verifying installed elm-test version...');
+exec('elm-test --version');
 
-echo(filename + ': Testing examples...')
+echo(filename + ': Testing examples...');
 
-cd('examples/tests')
-exec('elm-package install --yes')
-assertTestSuccess('PassingTests.elm')
-assertTestFailure('FailingTests.elm')
-cd('../..')
+cd('examples/tests');
+exec('elm-package install --yes');
+assertTestSuccess('PassingTests.elm');
+assertTestFailure('FailingTests.elm');
+cd('../..');
 
-echo(filename + ': Testing elm-test init...')
-mkdir('-p', 'tmp')
-cd('tmp')
-exec('elm-test init --yes')
-cd('tests')
-exec('elm-package install --yes')
-cd('..')
+echo(filename + ': Testing elm-test init...');
+mkdir('-p', 'tmp');
+cd('tmp');
+exec('elm-test init --yes');
+cd('tests');
+exec('elm-package install --yes');
+cd('..');
 // TODO fix test; it always fails, but running the steps manually, they succeed.
 // assertTestFailure()
 
 // delete the failing test and the comma on the preceding line
-sed('-i', /.*should fail.*/, '', 'tests/Tests.elm')
-sed('-i', /abcdefg"\)\),/, 'abcdefg"))', 'tests/Tests.elm')
-rm('-Rf', 'tests/elm-stuff')
-cd('tests')
-exec('elm-package install --yes')
-cd('..')
+sed('-i', /.*should fail.*/, '', 'tests/Tests.elm');
+sed('-i', /abcdefg"\)\),/, 'abcdefg"))', 'tests/Tests.elm');
+rm('-Rf', 'tests/elm-stuff');
+cd('tests');
+exec('elm-package install --yes');
+cd('..');
 // TODO fix test; it always fails, but running the steps manually, they succeed.
 // assertTestSuccess()
 
-cd('..')
-rm('-Rf', 'tmp')
+cd('..');
+rm('-Rf', 'tmp');
 
-echo('')
-echo(filename + ': Everything looks good!')
-echo('                                                            ')
-echo('  __   ,_   _  __,  -/-     ,         __   __   _   ,    ,  ')
-echo('_(_/__/ (__(/_(_/(__/_    _/_)__(_/__(_,__(_,__(/__/_)__/_)_')
-echo(' _/_                                                        ')
-echo('(/                                                          ')
+echo('');
+echo(filename + ': Everything looks good!');
+echo('                                                            ');
+echo('  __   ,_   _  __,  -/-     ,         __   __   _   ,    ,  ');
+echo('_(_/__/ (__(/_(_/(__/_    _/_)__(_/__(_,__(_,__(/__/_)__/_)_');
+echo(' _/_                                                        ');
+echo('(/                                                          ');

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -56,18 +56,16 @@ exec('elm-test init --yes');
 cd('tests');
 exec('elm-package install --yes');
 cd('..');
-// TODO fix test; it always fails, but running the steps manually, they succeed.
-// assertTestFailure()
+assertTestFailure();
 
-// delete the failing test and the comma on the preceding line
-sed('-i', /.*should fail.*/, '', 'tests/Tests.elm');
-sed('-i', /abcdefg"\)\),/, 'abcdefg"))', 'tests/Tests.elm');
+// update failing test to passing test
+sed('-i', /should fail/, 'should pass', 'tests/Tests.elm');
+sed('-i', /Expect.fail "failed as expected!"/, 'Expect.pass', 'tests/Tests.elm');
 rm('-Rf', 'tests/elm-stuff');
 cd('tests');
 exec('elm-package install --yes');
 cd('..');
-// TODO fix test; it always fails, but running the steps manually, they succeed.
-// assertTestSuccess()
+assertTestSuccess();
 
 cd('..');
 rm('-Rf', 'tmp');


### PR DESCRIPTION
Feel free to ignore the 1st commit as it only adds semicolons - no functional changes - it just made the editing more pleasant once the IDE was happy.

2nd commit - proposed fix for issue #44. This code changes the sed regex's to update the failing test to a passing test rather than trying to remove it completely which is troublesome as it is across multiple lines.