### PR TITLE
Adds error handler for errors thrown from Elm when js and Elm are out of sync

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -238,7 +238,7 @@ process.on('uncaughtException', function(error) {
     // This module does not take arguments though! You probably need to change the
     // initialization code to something like `Elm.Main.fullscreen()`]"
     console.error("Error starting the node-test-runner.");
-    console.error("Please check your javascript node-test-runner and Elm node-test runner packages versions are compatible");
+    console.error("Please check your Javascript 'elm-test' and Elm 'node-test-runner' package versions are compatible");
   } else {
     console.error("Unhandled exception while running the tests:", error);
   }

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -229,3 +229,17 @@ findUp('elm-package.json', { cwd: path.dirname(testFile) })
             });
         });
 });
+
+
+process.on('uncaughtException', function(error) {
+  if (/ an argument in Javascript/.test(error)) {
+    // Handle arg mismatch between js and elm code. Expected message from Elm:
+    // "You are giving module `Main` an argument in JavaScript.
+    // This module does not take arguments though! You probably need to change the
+    // initialization code to something like `Elm.Main.fullscreen()`]"
+    console.error("Error starting the node-test-runner.");
+    console.error("Please check your javascript node-test-runner and Elm node-test runner packages versions are compatible");
+  } else {
+    console.error("Unhandled exception while running the tests:", error);
+  }
+});


### PR DESCRIPTION
During a recent install I found that the versions of js and Elm code for running tests got out of step due to the version policies in my project:

npm -> "elm-test": "^0.17.1"
elm  -> "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
 
What was actually installed were:

elm-test v0.17.3
node-test-runner v1.0.0

Running the tests then gave rise to the following confusing error message:
```
elm-test tests/TestRunnerConsole.elm

Success! Compiled 1 module.
Successfully generated /var/folders/yb/mpcltqwx43n6h1k80xx_wbr40000gn/T/elm_test_116721-3561-1fvf9jf.js
undefined:1929
      throw new Error(
      ^

Error: You are giving module `Main` an argument in JavaScript.
This module does not take arguments though! You probably need to change the
initialization code to something like `Elm.Main.fullscreen()`
...
...
...
```

This PR tries to give the user a more informative error message in this situation. The main down side of this approach is the loss of the stack-trace to the console - but as that relates to a temporary file that is deleted it isn' very useful.



