### PR TITLE
Adds example fuzz test

### DIFF
--- a/templates/Tests.elm
+++ b/templates/Tests.elm
@@ -1,5 +1,6 @@
 module Tests exposing (..)
 
+import Fuzz exposing (string)
 import Test exposing (..)
 import Expect
 import String
@@ -17,4 +18,12 @@ all =
         , test "This test should fail" <|
             \() ->
                 Expect.fail "failed as expected!"
+        , fuzz string "This test runs multiple times with randomly generated strings based on the initial seed" <|
+            \randomlyGeneratedString ->
+                randomlyGeneratedString
+                    |> String.reverse
+                    |> String.reverse
+                    |> Expect.equal randomlyGeneratedString
+          -- uncomment the line below to see the values being used in the console when the test runs!
+          -- |> Debug.log randomlyGeneratedString
         ]


### PR DESCRIPTION
Not sure if this is what you were looking for as a fix for #64 

Adds a copy of elm-test example fuzz from docs added to template with slight rewording.

Added commented out Debug.log statement as a quick way for people to see the types of values being tested.
