### PR TITLE
Add fuzz tests to template

### DIFF
--- a/templates/Tests.elm
+++ b/templates/Tests.elm
@@ -2,19 +2,36 @@ module Tests exposing (..)
 
 import Test exposing (..)
 import Expect
+import Fuzz exposing (list, int, tuple, string)
 import String
 
 
 all : Test
 all =
-    describe "A Test Suite"
-        [ test "Addition" <|
-            \() ->
-                Expect.equal (3 + 7) 10
-        , test "String.left" <|
-            \() ->
-                Expect.equal "a" (String.left 1 "abcdefg")
-        , test "This test should fail" <|
-            \() ->
-                Expect.fail "failed as expected!"
+    describe "Sample Test Suite"
+        [ describe "Unit test examples"
+            [ test "Addition" <|
+                \() ->
+                    Expect.equal (3 + 7) 10
+            , test "String.left" <|
+                \() ->
+                    Expect.equal "a" (String.left 1 "abcdefg")
+            , test "This test should fail - you should remove it" <|
+                \() ->
+                    Expect.fail "Failed as expected!"
+            ]
+        , describe "Fuzz test examples, using randomly generated input"
+            [ fuzz (list int) "Lists always have positive length" <|
+                \aList ->
+                    List.length aList |> Expect.atLeast 0
+            , fuzz (list int) "Sorting a list does not change its length" <|
+                \aList ->
+                    List.sort aList |> List.length |> Expect.equal (List.length aList)
+            , fuzzWith { runs = 1000 } int "List.member will find an integer in a list containing it" <|
+                \i ->
+                    List.member i [ i ] |> Expect.true "If you see this, List.member returned False!"
+            , fuzz2 string string "The length of a string equals the sum of its substrings' lengths" <|
+                \s1 s2 ->
+                    s1 ++ s2 |> String.length |> Expect.equal (String.length s1 + String.length s2)
+            ]
         ]


### PR DESCRIPTION
Add several example fuzz tests to show off the library, and a few other tweaks to the template.

I didn't see #67 until I went to make this PR, sorry! (That said, I really dislike the reversing-a-list-twice standard example from QuickCheck...)