### PR TITLE
Use downward arrow in error messages.

### DIFF
--- a/src/Chalk.elm
+++ b/src/Chalk.elm
@@ -1,6 +1,7 @@
 module Chalk exposing (Chalk, encode, withColorChar)
 
 import Json.Encode as Encode exposing (Value)
+import String
 
 
 type alias Chalk =
@@ -16,5 +17,5 @@ encode { styles, text } =
 
 
 withColorChar : Char -> String -> String -> Chalk
-withColorChar char textColor str =
-    { styles = [ textColor ], text = "✗ " ++ str ++ "\n" }
+withColorChar icon textColor str =
+    { styles = [ textColor ], text = String.fromChar icon ++ " " ++ str ++ "\n" }


### PR DESCRIPTION
Chalk.elm hard-coded the x icon and never printed the arrow. This fixes that.

(Unless you wanted to not use the arrow for some reason?)