### PR TITLE
Add optional json output from test runner

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -26,10 +26,11 @@ var args = minimist(process.argv.slice(2), {
         'yes': 'y',
         'seed': 's',
         'compiler': 'c',
+        'report': 'r',
         'watch': 'w'
     },
     boolean: [ 'yes', 'warn', 'version', 'help', 'watch' ],
-    string: [ 'compiler', 'seed' ]
+    string: [ 'compiler', 'seed', 'report' ]
 });
 
 if (args.help) {
@@ -37,6 +38,7 @@ if (args.help) {
   console.log("Usage: elm-test TESTFILE [--compiler /path/to/compiler] # Run TESTFILE\n");
   console.log("Usage: elm-test [--compiler /path/to/compiler] # Run tests/Main.elm\n");
   console.log("Usage: elm-test [--seed integer] # Run with initial fuzzer seed\n");
+  console.log("Usage: elm-test [--report json or chalk (default)] # Print results to stdout in given format\n");
   console.log("Usage: elm-test [--watch] # Run tests on file changes\n");
   process.exit(1);
 }
@@ -45,6 +47,12 @@ if (args.version) {
   console.log(require(path.join(__dirname, "..", "package.json")).version);
   process.exit(0);
 }
+
+var report = "chalk";
+if (args.report !== undefined) {
+  report = args.report;
+}
+
 
 checkNodeVersion();
 
@@ -129,6 +137,9 @@ function evalElmCode (compiledCode, testModuleName) {
     initialSeed = args.seed;
   }
 
+
+
+
   // Apply Node polyfills as necessary.
   var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
   var document = {body: {}, createTextNode: function() {}};
@@ -162,7 +173,7 @@ function evalElmCode (compiledCode, testModuleName) {
   }
 
   // Run the Elm app.
-  var app = testModule.worker(initialSeed);
+  var app = testModule.worker({seed: initialSeed, report: report});
 
   // Receive messages from ports and translate them into appropriate JS calls.
   app.ports.emit.subscribe(function(msg) {
@@ -170,22 +181,34 @@ function evalElmCode (compiledCode, testModuleName) {
     var data = msg[1];
 
     if (msgType === 'FINISHED') {
+      if (data.format === "CHALK") {
         console.log(chalkify(data.message));
-        if (!args.watch) {
-            process.exit(data.exitCode);
+      } else {
+        console.log(JSON.stringify(data.message));
+      }
+
+      if (!args.watch) {
+        process.exit(data.exitCode);
+      }
+    } else if (msgType === "STARTED" || msgType === "TEST_COMPLETED")  {
+        if (data.format === "CHALK") {
+          console.log(chalkify(data.message));
+        } else {
+          console.log(JSON.stringify(data.message));
         }
-    } else if (msgType === 'CHALK') {
-        console.log(chalkify(data));
+
     }
   });
 }
+
 
 var testFile = args._[0],
     cwd = __dirname,
     pathToMake = undefined;
 
 function spawnCompiler(cmd, args, opts) {
-  var compilerOpts = _.defaults({stdio: "inherit"}, opts);
+  var compilerOpts =
+      _.defaults({stdio: [process.stdin, report === "chalk" ? process.stdout : 'ignore', process.stderr] }, opts);
 
   return spawn(cmd, args, compilerOpts);
 }
@@ -217,6 +240,12 @@ var testModulePromise = firstline(testFile).then(function (testModuleLine) {
     return 'Main';
 });
 
+function infoLog(msg) {
+  if (report === "chalk") {
+    console.log(msg);
+  }
+}
+
 findUp('elm-package.json', { cwd: path.dirname(testFile) })
     .then(function (elmPackagePath) {
         var elmRootDir = path.dirname(elmPackagePath);
@@ -226,7 +255,7 @@ findUp('elm-package.json', { cwd: path.dirname(testFile) })
         }
 
         if (args.watch) {
-            console.log('Running in watch mode');
+            infoLog('Running in watch mode');
 
             var watcher = chokidar.watch('**/*.elm', { ignoreInitial: true });
 
@@ -242,7 +271,7 @@ findUp('elm-package.json', { cwd: path.dirname(testFile) })
                 var relativePath = path.relative(elmRootDir, filePath);
                 var eventName = eventNameMap[event] || event;
 
-                console.log('\n' + relativePath + ' ' + eventName + '. Rebuilding!');
+                infoLog('\n' + relativePath + ' ' + eventName + '. Rebuilding!');
 
                 runTests();
             });

--- a/src/Test/Reporter/Chalk.elm
+++ b/src/Test/Reporter/Chalk.elm
@@ -1,0 +1,123 @@
+module Test.Reporter.Chalk exposing (reportBegin, reportComplete, reportSummary)
+
+import Chalk exposing (Chalk)
+import Test.Reporter.Result as Results
+import Expect
+import Json.Encode as Encode exposing (Value)
+import String
+import Test.Runner exposing (formatLabels)
+import Time exposing (Time)
+
+
+formatDuration : Time -> String
+formatDuration time =
+    toString time ++ " ms"
+
+
+indent : String -> String
+indent str =
+    str
+        |> String.split "\n"
+        |> List.map ((++) "    ")
+        |> String.join "\n"
+
+
+pluralize : String -> String -> Int -> String
+pluralize singular plural count =
+    let
+        suffix =
+            if count == 1 then
+                singular
+            else
+                plural
+    in
+        String.join " " [ toString count, suffix ]
+
+
+failuresToChalk : List String -> List Results.Failure -> List Chalk
+failuresToChalk labels failures =
+    labelsToChalk labels ++ List.concatMap failureToChalk failures
+
+
+labelsToChalk : List String -> List Chalk
+labelsToChalk =
+    formatLabels (Chalk.withColorChar '↓' "dim") (Chalk.withColorChar '✗' "red")
+
+
+failureToChalk : Results.Failure -> List Chalk
+failureToChalk { given, message } =
+    let
+        messageChalk =
+            { styles = [], text = "\n" ++ indent message ++ "\n\n" }
+    in
+        if String.isEmpty given then
+            [ messageChalk ]
+        else
+            [ { styles = [ "dim" ], text = "\nGiven " ++ given ++ "\n" }
+            , messageChalk
+            ]
+
+
+chalkWith : List Chalk -> Value
+chalkWith chalks =
+    chalks
+        |> List.map Chalk.encode
+        |> Encode.list
+
+
+reportBegin : { testCount : Int, initialSeed : Int } -> Value
+reportBegin { testCount, initialSeed } =
+    chalkWith
+        [ { styles = []
+          , text =
+                "\nelm-test\n--------\n\nRunning "
+                    ++ pluralize "test" "tests" testCount
+                    ++ ". To reproduce these results, run: elm-test --seed "
+                    ++ toString initialSeed
+                    ++ "\n"
+          }
+        ]
+
+
+reportComplete : Results.TestResult -> Maybe Value
+reportComplete { duration, labels, expectations } =
+    case List.filterMap Expect.getFailure expectations of
+        [] ->
+            Nothing
+
+        failures ->
+            failuresToChalk labels failures
+                |> chalkWith
+                |> Just
+
+
+reportSummary : Time -> List Results.TestResult -> Value
+reportSummary duration results =
+    let
+        failed =
+            results
+                |> List.filter (.expectations >> List.all ((/=) Expect.pass))
+                |> List.length
+
+        headline =
+            if failed > 0 then
+                [ { styles = [ "underline", "red" ], text = "\nTEST RUN FAILED\n\n" } ]
+            else
+                [ { styles = [ "underline", "green" ], text = "\nTEST RUN PASSED\n\n" } ]
+
+        passed =
+            (List.length results) - failed
+
+        stat label value =
+            [ { styles = [ "dim" ], text = label }
+            , { styles = [], text = value ++ "\n" }
+            ]
+    in
+        [ headline
+        , stat "Duration: " (formatDuration duration)
+        , stat "Passed:   " (toString passed)
+        , stat "Failed:   " (toString failed)
+        ]
+            |> List.concat
+            |> List.map Chalk.encode
+            |> Encode.list

--- a/src/Test/Reporter/Json.elm
+++ b/src/Test/Reporter/Json.elm
@@ -1,0 +1,78 @@
+module Test.Reporter.Json exposing (reportBegin, reportComplete, reportSummary)
+
+import Test.Reporter.Result as Results
+import Expect exposing (Expectation)
+import Json.Encode as Encode exposing (Value)
+import Time exposing (Time)
+
+
+reportBegin : { testCount : Int, initialSeed : Int } -> Value
+reportBegin { testCount, initialSeed } =
+    Encode.object
+        [ ( "event", Encode.string "runStart" )
+        , ( "testCount", Encode.string <| toString testCount )
+        , ( "initialSeed", Encode.string <| toString initialSeed )
+        ]
+
+
+reportComplete : Results.TestResult -> Maybe Value
+reportComplete { duration, labels, expectations } =
+    Just
+        <| Encode.object
+            [ ( "event", Encode.string "testCompleted" )
+            , ( "status", Encode.string (getStatus expectations) )
+            , ( "labels", encodeLabels labels )
+            , ( "failures", encodeFailures expectations )
+            , ( "duration", Encode.string <| toString duration )
+            ]
+
+
+getStatus : List Expectation -> String
+getStatus expectations =
+    case (List.filterMap Expect.getFailure expectations) of
+        [] ->
+            "pass"
+
+        xs ->
+            "fail"
+
+
+encodeLabels : List String -> Value
+encodeLabels labels =
+    List.reverse labels
+        |> List.map Encode.string
+        |> Encode.list
+
+
+encodeFailures : List Expectation -> Value
+encodeFailures expectations =
+    List.filterMap Expect.getFailure expectations
+        |> List.map encodeFailure
+        |> Encode.list
+
+
+encodeFailure : Results.Failure -> Value
+encodeFailure { given, message } =
+    Encode.object
+        [ ( "given", Encode.string given )
+        , ( "actual", Encode.string message )
+        ]
+
+
+reportSummary : Time -> List Results.TestResult -> Value
+reportSummary duration results =
+    let
+        failed =
+            results
+                |> List.filter (.expectations >> List.all ((/=) Expect.pass))
+                |> List.length
+
+        passed =
+            (List.length results) - failed
+    in
+        Encode.object
+            [ ( "event", Encode.string "runComplete" )
+            , ( "passed", Encode.string <| toString passed )
+            , ( "failed", Encode.string <| toString failed )
+            , ( "duration", Encode.string <| toString duration )
+            ]

--- a/src/Test/Reporter/Reporter.elm
+++ b/src/Test/Reporter/Reporter.elm
@@ -1,0 +1,36 @@
+module Test.Reporter.Reporter exposing (..)
+
+import Test.Reporter.Chalk as ChalkReporter
+import Test.Reporter.Json as JsonReporter
+import Test.Reporter.Result exposing (TestResult)
+import Json.Encode as Encode exposing (Value)
+import Time exposing (Time)
+
+
+type Report
+    = ChalkReport
+    | JsonReport
+
+
+type alias TestReporter =
+    { format : String
+    , reportBegin : { testCount : Int, initialSeed : Int } -> Value
+    , reportComplete : TestResult -> Maybe Value
+    , reportSummary : Time -> List TestResult -> Value
+    }
+
+
+createReporter : Report -> TestReporter
+createReporter report =
+    case report of
+        JsonReport ->
+            TestReporter "JSON"
+                JsonReporter.reportBegin
+                JsonReporter.reportComplete
+                JsonReporter.reportSummary
+
+        ChalkReport ->
+            TestReporter "CHALK"
+                ChalkReporter.reportBegin
+                ChalkReporter.reportComplete
+                ChalkReporter.reportSummary

--- a/src/Test/Reporter/Result.elm
+++ b/src/Test/Reporter/Result.elm
@@ -1,0 +1,15 @@
+module Test.Reporter.Result exposing (TestResult, Failure)
+
+import Expect exposing (Expectation)
+import Time exposing (Time)
+
+
+type alias TestResult =
+    { labels : List String
+    , expectations : List Expectation
+    , duration : Time
+    }
+
+
+type alias Failure =
+    { given : String, message : String }


### PR DESCRIPTION
**TLDR:** This pull request add support for outputting test results as JSON. You can now get results in json format as follows:
`elm-test --report=json`

## Background
For tooling purposes (my angle is editor integration) it would be very useful to have a more structured format for integrating with elm-test. JSON seems like a suitable place to start and should hopefully be useful for most editors and other tools.

## Solution overview
![screen shot 2016-10-09 at 15 47 45](https://cloud.githubusercontent.com/assets/399197/19220873/cad616fe-8e37-11e6-98e4-3a4726a2a856.png)

- Refactored out the existing Chalk related reporting into a separate module
- Added a JSon reporter module
- Added a module for shared types between the two `Test.Reporter.Result` (might be overkill ?) 
- Added a module `Test.Reporter.Reporter` which creates a `TestReporter` record to try to encapsulate the Node runner from dealing with which format is being used


## Testing
I wasn't able to get the bundled `tests\ci.js`to work properly on my machine, not sure what I'm doing wrong. I'm happy to try to get some sort of testing running for the new stuff if you think it's necessary (which I'm guessing the answer to would be yes). I have tested manually on the command-line with a couple of projects and have successfully integrated with the runner from Light Table.

## Other improvements
- Related issue in elm-test: https://github.com/elm-community/elm-test/issues/74




