### PR TITLE
Fix tests/ using local node-test-runner for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 elm-stuff
+tmp

--- a/templates/elm-package.json
+++ b/templates/elm-package.json
@@ -9,8 +9,11 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0",
         "rtfeldman/node-test-runner": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"

--- a/templates/elm-package.json
+++ b/templates/elm-package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "2.1.0 <= v < 3.0.0"
+        "rtfeldman/node-test-runner": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
> Fix tests/ using local node-test-runner for tests

Currently master fails with:

```log
elm-package: elm-stuff/exact-dependencies.json: openBinaryFile: does not exist (No such file or directory)
elm-make: elm-stuff/exact-dependencies.json: openBinaryFile: does not exist (No such file or directory)
Compilation failed for Main.elm
elm-package: elm-stuff/exact-dependencies.json: openBinaryFile: does not exist (No such file or directory)
elm-make: elm-stuff/exact-dependencies.json: openBinaryFile: does not exist (No such file or directory)
Compilation failed for Main.elm
ci.js: ERROR: Expected tests to pass
npm ERR! Test failed.  See above for more details.
```

## What Changed ✏️ 

* adds tmp to gitignore
* fixes dependencies of templates
* use local node-test-runner for ci tests