### PR TITLE
Fix polyfilling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 elm-stuff
+tmp

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -108,6 +108,12 @@ if (args._[0] == "init") {
 }
 
 function evalElmCode (compiledCode, testModuleName) {
+  // Apply Node polyfills as necessary.
+  var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
+  var document = {body: {}, createTextNode: function() {}};
+  if (typeof XMLHttpRequest === 'undefined') { XMLHttpRequest = function() { return { addEventListener: function() {}, open: function() {}, send: function() {} }; }; }
+  if (typeof FormData === 'undefined') { FormData = function () { this._data = []; }; FormData.prototype.append = function () { this._data.push(Array.prototype.slice.call(arguments)); }; }
+
   var Elm = function(module) { eval(compiledCode); return module.exports; }({});
 
   // Make sure necessary things are defined.
@@ -139,13 +145,7 @@ function evalElmCode (compiledCode, testModuleName) {
 
 
 
-
-  // Apply Node polyfills as necessary.
-  var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
-  var document = {body: {}, createTextNode: function() {}};
   pathToMake = args.compiler;
-  if (typeof XMLHttpRequest === 'undefined') { XMLHttpRequest = function() { return { addEventListener: function() {}, open: function() {}, send: function() {} }; }; }
-  if (typeof FormData === 'undefined') { FormData = function () { this._data = []; }; FormData.prototype.append = function () { this._data.push(Array.prototype.slice.call(arguments)); }; }
 
   // Fix Windows Unicode problems. Credit to https://github.com/sindresorhus/figures for the Windows compat idea!
   var windowsSubstitutions = [[/[↓✗►]/g, '>'], [/╵│╷╹┃╻/g, '|'], [/═/g, '='],, [/▔/g, '-'], [/✔/g, '√']];

--- a/examples/tests/Native/Polyfilled.js
+++ b/examples/tests/Native/Polyfilled.js
@@ -1,0 +1,10 @@
+if (!window) {
+    console.error('window not polyfilled');
+    process.exit(1);
+}
+var _rtfeldman$node_test_runner$Native_Polyfilled = function()
+{
+    return {
+      identity : function(x) { return x; }
+    };
+}();

--- a/examples/tests/PassingTests.elm
+++ b/examples/tests/PassingTests.elm
@@ -6,6 +6,11 @@ import Test exposing (..)
 import Json.Encode exposing (Value)
 
 
+-- Native.Polyfilled is only for testing node-test-runner
+
+import Native.Polyfilled
+
+
 main : Program Value
 main =
     [ plainExpectation ]

--- a/examples/tests/elm-package.json
+++ b/examples/tests/elm-package.json
@@ -8,6 +8,7 @@
         "../../src"
     ],
     "exposed-modules": [],
+    "native-modules": true,
     "dependencies": {
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
         "elm-community/json-extra": "1.0.0 <= v < 2.0.0",

--- a/templates/elm-package.json
+++ b/templates/elm-package.json
@@ -9,8 +9,11 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0",
         "rtfeldman/node-test-runner": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"

--- a/templates/elm-package.json
+++ b/templates/elm-package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "2.1.0 <= v < 3.0.0"
+        "rtfeldman/node-test-runner": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
> Polyfill before creating `Elm` eval functions.

Some modules try to access `window` on `import`. i.e. https://github.com/elm-lang/animation-frame/blob/1.0.0/src/Native/AnimationFrame.js

## What Changed ✏️ 

* adds `Native.Polyfilled` to demo bug.
* moves polyfilling before `var Elm = function(module) { eval(compiledCode); return module.exports; }({});`

### Note 📝 

This includes commits from #83. Please merge that PR first and I will rebase.