### PR TITLE
Provide a better error message for misuse of --report

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -49,10 +49,12 @@ if (args.version) {
 }
 
 var report = "chalk";
-if (args.report !== undefined) {
-  report = args.report;
+if (args.report === "chalk" || args.report == "json") {
+    report = args.report;
+} else if (args.report !== undefined) {
+    console.error("The --report option must be given either 'chalk' or 'json'");
+    process.exit(1);
 }
-
 
 checkNodeVersion();
 


### PR DESCRIPTION
I ran `elm test --report` hoping to see json output and got a very bizarre error message instead. This change catches when --report is not passed an argument, as well as an argument other than what's expected.