### PR TITLE
Bump template package versions

### DIFF
--- a/templates/elm-package.json
+++ b/templates/elm-package.json
@@ -9,9 +9,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0",
+        "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"


### PR DESCRIPTION
Issue:
```
$ elm-test init
...
$ elm-test
Error: I cannot find a set of packages that works with your constraints.

--> Your elm-package.json has the following dependency:
    
        "elm-community/json-extra": "1.0.0 <= v < 2.0.0"
    
    But none of the versions in that range work with Elm 0.18.0. I recommend
    removing that dependency by hand and adding it back with:
    
        elm-package install elm-community/json-extra 2.0.0

--> Your elm-package.json has the following dependency:
    
        "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0"
    
    But none of the versions in that range work with Elm 0.18.0. I recommend
    removing that dependency by hand and adding it back with:
    
        elm-package install mgold/elm-random-pcg 4.0.2

--> Your elm-package.json has the following dependency:
    
        "elm-lang/html": "1.0.0 <= v < 2.0.0"
    
    But none of the versions in that range work with Elm 0.18.0. I recommend
    removing that dependency by hand and adding it back with:
    
        elm-package install elm-lang/html 2.0.0

$  elm-test --version
0.18.0
```

