### PR TITLE
make sure to catch any error throw by evalElm

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -299,7 +299,11 @@ findUp('elm-package.json', { cwd: path.dirname(testFile) })
                         }
                     } else {
                         testModulePromise.then(function (testModuleName) {
-                            evalElmCode(fs.readFileSync(dest, {encoding: "utf8"}), testModuleName);
+                            try { 
+                                evalElmCode(fs.readFileSync(dest, {encoding: "utf8"}), testModuleName);
+                            } catch (e) {
+                                console.error("Evaluating the Elm code gave an error preventing startup:\n", e); 
+                            }
                         });
                     }
                 });


### PR DESCRIPTION
Currently if you cause a runtime error with Elm test on startup, you will get no output. This is because the promise is greedy and swallows it, meaning it will return that it successfully compiled the output, but nothing else. This leads to builds seeing the process return as though they passed when really they were causing runtime errors!