### PR TITLE
adds --doctest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 node_modules
 elm-stuff
 tmp
+examples/tests/Doc

--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ install:
 script:
   - elm-test
 ```
+
+### Doc-Tests
+
+You can use `elm-test` to run your [doc-tests][1].
+This uses [`elm-doc-test`][1] under the hood. See `examples` or the [README.md](https://github.com/stoeffel/elm-doc-test/blob/master/Readme.md) of [`elm-doc-test`][1].
+
+```bash
+elm-test --doctest
+```
+
+[1] : https://github.com/stoeffel/elm-doc-test

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then add your tests to Tests.elm.
 ### Configuration
 
 The `--compiler` flag can be used to use a version of the Elm compiler that
-has not been install globally.
+has not been installed globally.
 
 ```
 npm install elm

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ This uses [`elm-doc-test`][1] under the hood. See `examples` or the [README.md](
 elm-test --doctest
 ```
 
-[1] : https://github.com/stoeffel/elm-doc-test
+[1]: https://github.com/stoeffel/elm-doc-test

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -53,291 +53,296 @@ if (args.version) {
 
 if (args.doctest) {
   var doctestModel = doctest.init(args);
-  console.log(doctestModel.config)
-  doctestModel.run(doctestModel.config);
-  console.log(doctestModel.config)
-  process.exit(0);
+  doctestModel.run(doctestModel.config, function () {
+    runElmTest();
+  });
+  args._[0] = "tests/Doc/Main.elm"
+  return;
+} else {
+  runElmTest();
 }
 
-var report = "chalk";
-if (args.report === "chalk" || args.report == "json") {
-    report = args.report;
-} else if (args.report !== undefined) {
-    console.error("The --report option must be given either 'chalk' or 'json'");
-    process.exit(1);
-}
-
-checkNodeVersion();
-
-function checkNodeVersion() {
-  var nodeVersionString = process.versions.node;
-  var nodeVersion = _.map(_.split(nodeVersionString, '.'), _.parseInt);
-
-  if((nodeVersion[0] === 0 && nodeVersion[1] < 11) ||
-     (nodeVersion[0] === 0 && nodeVersion[1] === 11 && nodeVersion[2] < 13)) {
-    console.log("using node v" + nodeVersionString);
-    console.error("elm-test requires node v0.11.13 or greater - upgrade the installed version of node and try again");
-    process.exit(1);
-  }
-}
-
-if (args._[0] == "init") {
-  var copyTemplate = function(templateName, destName) {
-    if (arguments.length == 1) {
-      destName = templateName;
-    }
-    var source = path.resolve(__dirname, "../templates/" + templateName);
-    var destination = path.resolve("tests", destName);
-    if (fs.existsSync(destination)) {
-      console.log(destination + " already exists");
-    } else {
-      fs.copySync(source, destination);
-      console.log("Created " + destination);
-    }
-  };
-
-  var ensureDirectory = function(dirName) {
-    var destination = path.resolve(".", dirName);
-    if (fs.existsSync(destination)) {
-      console.log(destination + " already exists");
-    } else {
-      fs.mkdirSync(destination);
-      console.log("Created " + destination);
-    }
-  };
-
-  var elmOptions = "";
-  if (args.yes) {
-    elmOptions += " --yes";
+function runElmTest() {
+  var report = "chalk";
+  if (args.report === "chalk" || args.report == "json") {
+      report = args.report;
+  } else if (args.report !== undefined) {
+      console.error("The --report option must be given either 'chalk' or 'json'");
+      process.exit(1);
   }
 
-  ensureDirectory("src");
-  ensureDirectory("tests");
-  copyTemplate("elm-package.json");
-  copyTemplate("Main.elm");
-  copyTemplate("Tests.elm");
-  copyTemplate("gitignore", ".gitignore");
-  process.exit(0);
-}
+  checkNodeVersion();
 
-function evalElmCode (compiledCode, testModuleName) {
-  // Apply Node polyfills as necessary.
-  var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
-  var document = {body: {}, createTextNode: function() {}};
-  if (typeof XMLHttpRequest === 'undefined') { XMLHttpRequest = function() { return { addEventListener: function() {}, open: function() {}, send: function() {} }; }; }
-  if (typeof FormData === 'undefined') { FormData = function () { this._data = []; }; FormData.prototype.append = function () { this._data.push(Array.prototype.slice.call(arguments)); }; }
+  function checkNodeVersion() {
+    var nodeVersionString = process.versions.node;
+    var nodeVersion = _.map(_.split(nodeVersionString, '.'), _.parseInt);
 
-  var Elm = function(module) { eval(compiledCode); return module.exports; }({});
+    if((nodeVersion[0] === 0 && nodeVersion[1] < 11) ||
+       (nodeVersion[0] === 0 && nodeVersion[1] === 11 && nodeVersion[2] < 13)) {
+      console.log("using node v" + nodeVersionString);
+      console.error("elm-test requires node v0.11.13 or greater - upgrade the installed version of node and try again");
+      process.exit(1);
+    }
+  }
 
-  // Make sure necessary things are defined.
-  if (typeof Elm === 'undefined') { throw 'elm-io config error: Elm is not defined. Make sure you provide a file compiled by Elm!'; }
-
-  function getTestModule() {
-      var module = Elm;
-      var moduleParts = testModuleName.split('.');
-      while (moduleParts.length) {
-          var modulePart = moduleParts.shift();
-          if (module[modulePart] === undefined) {
-              return undefined;
-          }
-
-          module = module[modulePart];
+  if (args._[0] == "init") {
+    var copyTemplate = function(templateName, destName) {
+      if (arguments.length == 1) {
+        destName = templateName;
       }
-
-      return module;
-  }
-
-  var testModule = getTestModule();
-  if (testModule === undefined) { throw 'Elm.' + testModuleName + ' is not defined. Make sure you provide a file compiled by Elm!'; }
-
-  var initialSeed = null;
-
-  if (args.seed !== undefined) {
-    initialSeed = args.seed;
-  }
-
-
-
-  pathToMake = args.compiler;
-
-  // Fix Windows Unicode problems. Credit to https://github.com/sindresorhus/figures for the Windows compat idea!
-  var windowsSubstitutions = [[/[↓✗►]/g, '>'], [/╵│╷╹┃╻/g, '|'], [/═/g, '='],, [/▔/g, '-'], [/✔/g, '√']];
-
-  function windowsify(str) {
-    return windowsSubstitutions.reduce(
-      function(result, sub) { return result.replace(sub[0], sub[1]); }, str);
-  }
-
-  function chalkify(messages) {
-    return messages.map(function(msg) {
-      var path = msg.styles;
-      var text = process.platform === 'win32' ? windowsify(msg.text) : msg.text;
-
-      if (path.length === 0) {
-        return text;
+      var source = path.resolve(__dirname, "../templates/" + templateName);
+      var destination = path.resolve("tests", destName);
+      if (fs.existsSync(destination)) {
+        console.log(destination + " already exists");
       } else {
-        var fn = chalk;
-
-        path.forEach(function(nextPath) { fn = fn[nextPath]; });
-
-        return fn(text);
+        fs.copySync(source, destination);
+        console.log("Created " + destination);
       }
-    }).join('');
+    };
+
+    var ensureDirectory = function(dirName) {
+      var destination = path.resolve(".", dirName);
+      if (fs.existsSync(destination)) {
+        console.log(destination + " already exists");
+      } else {
+        fs.mkdirSync(destination);
+        console.log("Created " + destination);
+      }
+    };
+
+    var elmOptions = "";
+    if (args.yes) {
+      elmOptions += " --yes";
+    }
+
+    ensureDirectory("src");
+    ensureDirectory("tests");
+    copyTemplate("elm-package.json");
+    copyTemplate("Main.elm");
+    copyTemplate("Tests.elm");
+    copyTemplate("gitignore", ".gitignore");
+    process.exit(0);
   }
 
-  // Run the Elm app.
-  var app = testModule.worker({seed: initialSeed, report: report});
+  function evalElmCode (compiledCode, testModuleName) {
+    // Apply Node polyfills as necessary.
+    var window = {Date: Date, addEventListener: function() {}, removeEventListener: function() {}};
+    var document = {body: {}, createTextNode: function() {}};
+    if (typeof XMLHttpRequest === 'undefined') { XMLHttpRequest = function() { return { addEventListener: function() {}, open: function() {}, send: function() {} }; }; }
+    if (typeof FormData === 'undefined') { FormData = function () { this._data = []; }; FormData.prototype.append = function () { this._data.push(Array.prototype.slice.call(arguments)); }; }
 
-  // Receive messages from ports and translate them into appropriate JS calls.
-  app.ports.emit.subscribe(function(msg) {
-    var msgType = msg[0];
-    var data = msg[1];
+    var Elm = function(module) { eval(compiledCode); return module.exports; }({});
 
-    if (msgType === 'FINISHED') {
-      if (data.format === "CHALK") {
-        console.log(chalkify(data.message));
-      } else {
-        console.log(JSON.stringify(data.message));
-      }
+    // Make sure necessary things are defined.
+    if (typeof Elm === 'undefined') { throw 'elm-io config error: Elm is not defined. Make sure you provide a file compiled by Elm!'; }
 
-      if (!args.watch) {
-        process.exit(data.exitCode);
-      }
-    } else if (msgType === "STARTED" || msgType === "TEST_COMPLETED")  {
+    function getTestModule() {
+        var module = Elm;
+        var moduleParts = testModuleName.split('.');
+        while (moduleParts.length) {
+            var modulePart = moduleParts.shift();
+            if (module[modulePart] === undefined) {
+                return undefined;
+            }
+
+            module = module[modulePart];
+        }
+
+        return module;
+    }
+
+    var testModule = getTestModule();
+    if (testModule === undefined) { throw 'Elm.' + testModuleName + ' is not defined. Make sure you provide a file compiled by Elm!'; }
+
+    var initialSeed = null;
+
+    if (args.seed !== undefined) {
+      initialSeed = args.seed;
+    }
+
+
+
+    pathToMake = args.compiler;
+
+    // Fix Windows Unicode problems. Credit to https://github.com/sindresorhus/figures for the Windows compat idea!
+    var windowsSubstitutions = [[/[↓✗►]/g, '>'], [/╵│╷╹┃╻/g, '|'], [/═/g, '='],, [/▔/g, '-'], [/✔/g, '√']];
+
+    function windowsify(str) {
+      return windowsSubstitutions.reduce(
+        function(result, sub) { return result.replace(sub[0], sub[1]); }, str);
+    }
+
+    function chalkify(messages) {
+      return messages.map(function(msg) {
+        var path = msg.styles;
+        var text = process.platform === 'win32' ? windowsify(msg.text) : msg.text;
+
+        if (path.length === 0) {
+          return text;
+        } else {
+          var fn = chalk;
+
+          path.forEach(function(nextPath) { fn = fn[nextPath]; });
+
+          return fn(text);
+        }
+      }).join('');
+    }
+
+    // Run the Elm app.
+    var app = testModule.worker({seed: initialSeed, report: report});
+
+    // Receive messages from ports and translate them into appropriate JS calls.
+    app.ports.emit.subscribe(function(msg) {
+      var msgType = msg[0];
+      var data = msg[1];
+
+      if (msgType === 'FINISHED') {
         if (data.format === "CHALK") {
           console.log(chalkify(data.message));
         } else {
           console.log(JSON.stringify(data.message));
         }
 
+        if (!args.watch) {
+          process.exit(data.exitCode);
+        }
+      } else if (msgType === "STARTED" || msgType === "TEST_COMPLETED")  {
+          if (data.format === "CHALK") {
+            console.log(chalkify(data.message));
+          } else {
+            console.log(JSON.stringify(data.message));
+          }
+
+      }
+    });
+  }
+
+
+  var testFile = args._[0],
+      cwd = __dirname,
+      pathToMake = undefined;
+
+  function spawnCompiler(cmd, args, opts) {
+    var compilerOpts =
+        _.defaults({stdio: [process.stdin, report === "chalk" ? process.stdout : 'ignore', process.stderr] }, opts);
+
+    return spawn(cmd, args, compilerOpts);
+  }
+
+  if (typeof testFile == "undefined") {
+    testFile = "tests/Main.elm";
+  }
+
+  if (args.compiler !== undefined) {
+    pathToMake = args.compiler;
+
+    if (!pathToMake) {
+      console.error("The --compiler option must be given a path to an elm-make executable.");
+      process.exit(1);
     }
-  });
-}
+  }
 
-
-var testFile = args._[0],
-    cwd = __dirname,
-    pathToMake = undefined;
-
-function spawnCompiler(cmd, args, opts) {
-  var compilerOpts =
-      _.defaults({stdio: [process.stdin, report === "chalk" ? process.stdout : 'ignore', process.stderr] }, opts);
-
-  return spawn(cmd, args, compilerOpts);
-}
-
-if (typeof testFile == "undefined") {
-  testFile = "tests/Main.elm";
-}
-
-if (args.compiler !== undefined) {
-  pathToMake = args.compiler;
-
-  if (!pathToMake) {
-    console.error("The --compiler option must be given a path to an elm-make executable.");
+  if (!fs.existsSync(testFile)) {
+    console.error("Could not find file " + testFile);
     process.exit(1);
   }
-}
 
-if (!fs.existsSync(testFile)) {
-  console.error("Could not find file " + testFile);
-  process.exit(1);
-}
+  var testModulePromise = firstline(testFile).then(function (testModuleLine) {
+      var moduleMatches = testModuleLine.match(/^(?:port\s+)?module\s+([^\s]+)/);
+      if (moduleMatches) {
+          return moduleMatches[1];
+      }
 
-var testModulePromise = firstline(testFile).then(function (testModuleLine) {
-    var moduleMatches = testModuleLine.match(/^(?:port\s+)?module\s+([^\s]+)/);
-    if (moduleMatches) {
-        return moduleMatches[1];
+      return 'Main';
+  });
+
+  function infoLog(msg) {
+    if (report === "chalk") {
+      console.log(msg);
     }
-
-    return 'Main';
-});
-
-function infoLog(msg) {
-  if (report === "chalk") {
-    console.log(msg);
   }
-}
 
-findUp('elm-package.json', { cwd: path.dirname(testFile) })
-    .then(function (elmPackagePath) {
-        var elmRootDir = path.dirname(elmPackagePath);
-        if (fs.realpathSync(elmRootDir) !== fs.realpathSync(process.cwd())) {
-            testFile = path.relative(elmRootDir, testFile);
-            process.chdir(elmRootDir);
-        }
+  findUp('elm-package.json', { cwd: path.dirname(testFile) })
+      .then(function (elmPackagePath) {
+          var elmRootDir = path.dirname(elmPackagePath);
+          if (fs.realpathSync(elmRootDir) !== fs.realpathSync(process.cwd())) {
+              testFile = path.relative(elmRootDir, testFile);
+              process.chdir(elmRootDir);
+          }
 
-        if (args.watch) {
-            infoLog('Running in watch mode');
+          if (args.watch) {
+              infoLog('Running in watch mode');
 
-            var watcher = chokidar.watch('**/*.elm', { ignoreInitial: true });
+              var watcher = chokidar.watch('**/*.elm', { ignoreInitial: true });
 
-            var eventNameMap = {
-                add: 'added',
-                addDir: 'added',
-                change: 'changed',
-                unlink: 'removed',
-                unlinkDir: 'removed',
-            };
+              var eventNameMap = {
+                  add: 'added',
+                  addDir: 'added',
+                  change: 'changed',
+                  unlink: 'removed',
+                  unlinkDir: 'removed',
+              };
 
-            watcher.on('all', function (event, filePath) {
-                var relativePath = path.relative(elmRootDir, filePath);
-                var eventName = eventNameMap[event] || event;
+              watcher.on('all', function (event, filePath) {
+                  var relativePath = path.relative(elmRootDir, filePath);
+                  var eventName = eventNameMap[event] || event;
 
-                infoLog('\n' + relativePath + ' ' + eventName + '. Rebuilding!');
+                  infoLog('\n' + relativePath + ' ' + eventName + '. Rebuilding!');
 
-                runTests();
-            });
-        }
+                  runTests();
+              });
+          }
 
-        function runTests () {
-            temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
-                var dest = info.path;
-                var compileProcess = compile( [testFile], {
-                    output: dest,
-                    verbose: args.verbose,
-                    yes: true,
-                    spawn: spawnCompiler,
-                    pathToMake: pathToMake,
-                    warn:args.warn
-                });
+          function runTests () {
+              temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
+                  var dest = info.path;
+                  var compileProcess = compile( [testFile], {
+                      output: dest,
+                      verbose: args.verbose,
+                      yes: true,
+                      spawn: spawnCompiler,
+                      pathToMake: pathToMake,
+                      warn:args.warn
+                  });
 
-                compileProcess.on('close', function(exitCode) {
-                    if (exitCode !== 0) {
-                        console.error("Compilation failed for", testFile);
-                        if (!args.watch) {
-                            process.exit(exitCode);
-                        }
-                    } else {
-                        testModulePromise.then(function (testModuleName) {
-                            try {
-                                evalElmCode(fs.readFileSync(dest, {encoding: "utf8"}), testModuleName);
-                            } catch (err) {
-                                console.error("The test run failed because it encountered a runtime exception:\n\n", err);
+                  compileProcess.on('close', function(exitCode) {
+                      if (exitCode !== 0) {
+                          console.error("Compilation failed for", testFile);
+                          if (!args.watch) {
+                              process.exit(exitCode);
+                          }
+                      } else {
+                          testModulePromise.then(function (testModuleName) {
+                              try {
+                                  evalElmCode(fs.readFileSync(dest, {encoding: "utf8"}), testModuleName);
+                              } catch (err) {
+                                  console.error("The test run failed because it encountered a runtime exception:\n\n", err);
 
-                                if (!args.watch) {
-                                    process.exit(2);
-                                }
-                            }
-                        });
-                    }
-                });
-            });
-        }
+                                  if (!args.watch) {
+                                      process.exit(2);
+                                  }
+                              }
+                          });
+                      }
+                  });
+              });
+          }
 
-        runTests();
-    });
+          runTests();
+      });
 
 
-process.on('uncaughtException', function(error) {
-  if (/ an argument in Javascript/.test(error)) {
-    // Handle arg mismatch between js and elm code. Expected message from Elm:
-    // "You are giving module `Main` an argument in JavaScript.
-    // This module does not take arguments though! You probably need to change the
-    // initialization code to something like `Elm.Main.fullscreen()`]"
-    console.error("Error starting the node-test-runner.");
-    console.error("Please check your Javascript 'elm-test' and Elm 'node-test-runner' package versions are compatible");
-  } else {
-    console.error("Unhandled exception while running the tests:", error);
-  }
-});
+  process.on('uncaughtException', function(error) {
+    if (/ an argument in Javascript/.test(error)) {
+      // Handle arg mismatch between js and elm code. Expected message from Elm:
+      // "You are giving module `Main` an argument in JavaScript.
+      // This module does not take arguments though! You probably need to change the
+      // initialization code to something like `Elm.Main.fullscreen()`]"
+      console.error("Error starting the node-test-runner.");
+      console.error("Please check your Javascript 'elm-test' and Elm 'node-test-runner' package versions are compatible");
+    } else {
+      console.error("Unhandled exception while running the tests:", error);
+    }
+  });
+};

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -15,7 +15,8 @@ var compile    = require("node-elm-compiler").compile,
   minimist     = require("minimist"),
   firstline    = require("firstline"),
   findUp       = require("find-up"),
-  chokidar     = require("chokidar");
+  chokidar     = require("chokidar"),
+  doctest      = require("elm-doc-test/bin/modes");
 
 var elm = {
   'elm-package': 'elm-package'
@@ -47,6 +48,14 @@ if (args.help) {
 
 if (args.version) {
   console.log(require(path.join(__dirname, "..", "package.json")).version);
+  process.exit(0);
+}
+
+if (args.doctest) {
+  var doctestModel = doctest.init(args);
+  console.log(doctestModel.config)
+  doctestModel.run(doctestModel.config);
+  console.log(doctestModel.config)
   process.exit(0);
 }
 

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -27,9 +27,10 @@ var args = minimist(process.argv.slice(2), {
         'seed': 's',
         'compiler': 'c',
         'report': 'r',
-        'watch': 'w'
+        'watch': 'w',
+        'doctest': 'd'
     },
-    boolean: [ 'yes', 'warn', 'version', 'help', 'watch' ],
+    boolean: [ 'yes', 'warn', 'version', 'help', 'watch', 'doctest' ],
     string: [ 'compiler', 'seed', 'report' ]
 });
 
@@ -40,6 +41,7 @@ if (args.help) {
   console.log("Usage: elm-test [--seed integer] # Run with initial fuzzer seed\n");
   console.log("Usage: elm-test [--report json or chalk (default)] # Print results to stdout in given format\n");
   console.log("Usage: elm-test [--watch] # Run tests on file changes\n");
+  console.log("Usage: elm-test [--doctest] # Run doctests\n");
   process.exit(1);
 }
 

--- a/examples/DocTestExample.elm
+++ b/examples/DocTestExample.elm
@@ -1,0 +1,11 @@
+module DocTestExample exposing (..)
+
+{-|
+    >>> add 1 2
+    3
+-}
+
+
+add : Int -> Int -> Int
+add =
+    (+)

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -4,14 +4,11 @@
     "repository": "https://github.com/rtfeldman/node-test-runner.git",
     "license": "BSD-3-Clause",
     "source-directories": [
-        ".",
-        "..",
-        "../../src"
+        "."
     ],
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",

--- a/examples/tests/elm-doc-test.json
+++ b/examples/tests/elm-doc-test.json
@@ -1,0 +1,4 @@
+{
+  "root": "../",
+  "tests": ["DocTestExample"]
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chalk": "1.1.3",
     "chokidar": "1.6.0",
     "cross-spawn": "4.0.0",
+    "elm-doc-test": "^1.1.0",
     "find-up": "^1.1.2",
     "firstline": "^1.2.0",
     "fs-extra": "0.30.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chalk": "1.1.3",
     "chokidar": "1.6.0",
     "cross-spawn": "4.0.0",
-    "elm-doc-test": "^1.1.0",
+    "elm-doc-test": "1.2.0",
     "find-up": "^1.1.2",
     "firstline": "^1.2.0",
     "fs-extra": "0.30.0",

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -39,6 +39,25 @@ function assertTestSuccess(testFile) {
   }
 }
 
+function assertDocTest() {
+  var code = exec(elmTest + ' --doctest').code;
+  if (code !== 0) {
+    exec('Expected doc-tests to pass >&2');
+    exit(1);
+  }
+
+  sed('-i', /    >>> add 1 2/, '    >>> add 42 42', './DocTestExample.elm');
+
+  code = exec(elmTest + ' --doctest').code;
+  if (code !== 1) {
+    exec('Expected doc-tests to fail >&2');
+    exit(1);
+  }
+
+  sed('-i', /    >>> add 42 42/, '    >>> add 1 2', './DocTestExample.elm');
+}
+
+
 echo(filename + ': Installing elm-test...');
 exec('npm install --global');
 
@@ -52,6 +71,13 @@ exec('elm-package install --yes');
 assertTestSuccess('PassingTests.elm');
 assertTestFailure('FailingTests.elm');
 cd('../..');
+
+echo(filename + ': Testing doc-test...');
+
+cd('examples');
+assertDocTest();
+cd('..');
+
 
 echo(filename + ': Testing elm-test init...');
 rm('-Rf', 'tmp');

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -3,18 +3,20 @@
 require('shelljs/global');
 var _ = require('lodash');
 var fs = require('fs-extra');
+var path = require('path');
 
 var filename = __filename.replace(__dirname + '/', '');
+var elmTest = path.join(__dirname, '..', 'bin', 'elm-test');
 
 function run(testFile) {
   var logFile = 'elm-test.test.log';
   var retVal;
 
   if (!testFile) {
-    retVal = exec('elm-test');
+    retVal = exec(elmTest);
   } else {
     logFile = testFile + '.test.log';
-    retVal = exec('elm-test ' + testFile);
+    retVal = exec(elmTest + ' '+ testFile);
   }
 
   retVal.toEnd(logFile);
@@ -41,7 +43,7 @@ echo(filename + ': Installing elm-test...');
 exec('npm install --global');
 
 echo(filename + ': Verifying installed elm-test version...');
-exec('elm-test --version');
+exec(elmTest + ' --version');
 
 echo(filename + ': Testing examples...');
 
@@ -55,7 +57,7 @@ echo(filename + ': Testing elm-test init...');
 rm('-Rf', 'tmp');
 mkdir('-p', 'tmp');
 cd('tmp');
-exec('elm-test init --yes');
+exec(elmTest + ' init --yes');
 cd('tests');
 // use local node-test-runner
 var tmpPackage = fs.readJsonSync('./elm-package.json');


### PR DESCRIPTION
This allows a user to run doctests using `elm-test --doctest`. It will generate the doctests using https://github.com/stoeffel/elm-doc-test and then run them using `node-test-runner`.

Let me know what I should address.

Thanks!