### PR TITLE
main doc test

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -62,15 +62,20 @@ if (args.version) {
   process.exit(0);
 }
 
-if (args.doctest) {
-  var doctestModel = doctest.init(args);
-  doctestModel.run(doctestModel.config, function () {
+
+// Run elm-doc-tests
+var doctestModel = doctest.init({
+  warn: false,
+  output: path.join(generatedCodeDir, 'src')
+});
+
+if (doctestModel.config.tests.length <= 0) {
+  runElmTest(); // only run elm-tests
+} else {
+  doctestModel.run(doctestModel, function () {
+    // Run elm-tests
     runElmTest();
   });
-  args._[0] = "tests/Doc/Main.elm"
-  return;
-} else {
-  runElmTest();
 }
 
 function runElmTest() {
@@ -307,8 +312,8 @@ function runElmTest() {
   process.chdir(newElmPackageDir);
 
   // TODO stop hardcoding this
-  var imports = ["import FailingTests"]
-  var testList = ["FailingTests.tests"]
+  var imports = ["import FailingTests", "import Doc.Tests"]
+  var testList = ["FailingTests.tests", "Doc.Tests.all"]
 
   var testFileContents =
     // TODO use a module name that's less likely to cause namespace conflits

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -41,10 +41,9 @@ var args = minimist(process.argv.slice(2), {
         'seed': 's',
         'compiler': 'c',
         'report': 'r',
-        'watch': 'w',
-        'doctest': 'd'
+        'watch': 'w'
     },
-    boolean: [ 'yes', 'warn', 'version', 'help', 'watch', 'doctest' ],
+    boolean: [ 'yes', 'warn', 'version', 'help', 'watch'],
     string: [ 'compiler', 'seed', 'report' ]
 });
 
@@ -55,7 +54,6 @@ if (args.help) {
   console.log("Usage: elm-test [--seed integer] # Run with initial fuzzer seed\n");
   console.log("Usage: elm-test [--report json or chalk (default)] # Print results to stdout in given format\n");
   console.log("Usage: elm-test [--watch] # Run tests on file changes\n");
-  console.log("Usage: elm-test [--doctest] # Run doctests\n");
   process.exit(1);
 }
 

--- a/examples/DocTestExample.elm
+++ b/examples/DocTestExample.elm
@@ -3,6 +3,9 @@ module DocTestExample exposing (..)
 {-|
     >>> add 1 2
     3
+
+    >>> add 99 3
+    102
 -}
 
 

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -4,7 +4,8 @@
     "repository": "https://github.com/rtfeldman/node-test-runner.git",
     "license": "BSD-3-Clause",
     "source-directories": [
-        "tests"
+        "tests",
+        "."
     ],
     "exposed-modules": [],
     "native-modules": true,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chalk": "1.1.3",
     "chokidar": "1.6.0",
     "cross-spawn": "4.0.0",
-    "elm-doc-test": "1.2.0",
+    "elm-doc-test": "2.1.0",
     "firstline": "^1.2.0",
     "fs-extra": "0.30.0",
     "lodash": "4.13.1",


### PR DESCRIPTION
@rtfeldman removed the `doctest` flag and `elm-test` generates the doctests into `elm-stuff/generated-code/elm-community/elm-test/src/Doc` and the get imported into the generated `Main.elm`.

I hope that aligns with your plan for this. Let me know.

> This PR points to your branch `no-main`