### PR TITLE
Also watch src dir in watch mode

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -274,7 +274,8 @@ function runElmTest() {
           if (args.watch) {
               infoLog('Running in watch mode');
 
-              var watcher = chokidar.watch('**/*.elm', { ignoreInitial: true });
+              var watchedPaths = JSON.parse(fs.readFileSync(elmPackagePath, 'utf8'))['source-directories'].map(function(path) { return path + '/**/*.elm'; });
+              var watcher = chokidar.watch(watchedPaths, { ignoreInitial: true });
 
               var eventNameMap = {
                   add: 'added',


### PR DESCRIPTION
@megapctr [pointed out](https://github.com/elm-community/elm-test/issues/104) that `elm-test --watch` doesn't watch the src dir. This fixes that.