### PR TITLE
Avoid pipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
 sudo: false
 
-language: node_js
-node_js:
-  - "0.12"
+env:
+  matrix:
+    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
+    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
 
-addons:
-  apt:
-    sources:
-    - hvr-ghc
-    packages:
-    - cabal-install-1.22
-    - ghc-7.10.1
+install:
+  - nvm install $TARGET_NODE_VERSION
+  - nvm use $TARGET_NODE_VERSION
+  - node --version
+  - npm --version
+  - npm install -g elm@$ELM_VERSION
 
-
-before_install:
- - export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:./Elm-Platform/0.15.1/.cabal-sandbox/bin:$PATH
- - runhaskell BuildFromSource.hs 0.15.1
- - export PATH="`pwd`"/Elm-Platform/0.15.1/.cabal-sandbox/bin:$PATH
+script: ./ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,19 @@
+sudo: false
+
 language: node_js
 node_js:
   - "0.12"
+
+addons:
+  apt:
+    sources:
+    - hvr-ghc
+    packages:
+    - cabal-install-1.22
+    - ghc-7.10.1
+
+
+before_install:
+ - export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:./Elm-Platform/0.15.1/.cabal-sandbox/bin:$PATH
+ - runhaskell BuildFromSource.hs 0.15.1
+ - export PATH="`pwd`"/Elm-Platform/0.15.1/.cabal-sandbox/bin:$PATH

--- a/BuildFromSource.hs
+++ b/BuildFromSource.hs
@@ -1,0 +1,164 @@
+{-| This script builds any version of the Elm Platform from source.
+Before you use it, make sure you have the Haskell Platform with a recent
+version of cabal.
+
+To install a released version of Elm, you will run something like this:
+
+    runhaskell BuildFromSource.hs 0.15.1
+
+Before you do that, in some directory of your choosing, add
+wherever/Elm-Platform/0.15.1/.cabal-sandbox/bin to your PATH.
+
+Then, run the above. You will now actually have a new directory for the
+Elm Platform, like this:
+
+    Elm-Platform/0.15.1/
+        elm-make/        -- git repo for the build tool, ready to edit
+        elm-repl/        -- git repo for the REPL, ready to edit
+        ...
+        .cabal-sandbox/  -- various build files
+
+All of the executables you need are in .cabal-sandbox/bin, which is on
+your PATH and thus can be used from anywhere.
+
+You can build many versions of the Elm Platform, so it is possible to have
+Elm-Platform/0.15.1/ and Elm-Platform/0.13/ with no problems. It is up to you
+to manage your PATH variable or symlinks though.
+
+To get set up with the master branch of all Elm Platform projects, run this:
+
+    runhaskell BuildFromSource.hs master
+
+From there you can start developing on any of the projects, switching branches
+and testing interactions between projects.
+-}
+module Main where
+
+import qualified Data.List          as List
+import qualified Data.Map           as Map
+import           System.Directory   (createDirectoryIfMissing,
+                                     getCurrentDirectory, setCurrentDirectory)
+import           System.Environment (getArgs)
+import           System.Exit        (ExitCode, exitFailure)
+import           System.FilePath    ((</>))
+import           System.IO          (hPutStrLn, stderr)
+import           System.Process     (rawSystem)
+
+
+(=:) = (,)
+
+configs :: Map.Map String [(String, String)]
+configs =
+  Map.fromList
+    [
+      "master" =:
+        [ "elm-compiler" =: "master"
+        , "elm-package"  =: "master"
+        , "elm-make"     =: "master"
+        , "elm-reactor"  =: "master"
+        , "elm-repl"     =: "master"
+        ]
+    ,
+      "0.15.1" =:
+        [ "elm-compiler" =: "0.15.1"
+        , "elm-package"  =: "0.5.1"
+        , "elm-make"     =: "0.2"
+        ]
+    ,
+      "0.15" =:
+        [ "elm-compiler" =: "0.15"
+        , "elm-package"  =: "0.5"
+        , "elm-make"     =: "0.1.2"
+        , "elm-reactor"  =: "0.3.1"
+        , "elm-repl"     =: "0.4.1"
+        ]
+    ,
+      "0.14.1" =:
+        [ "elm-compiler" =: "0.14.1"
+        , "elm-package"  =: "0.4"
+        , "elm-make"     =: "0.1.1"
+        , "elm-reactor"  =: "0.3"
+        , "elm-repl"     =: "0.4"
+        ]
+    ,
+      "0.14" =:
+        [ "elm-compiler" =: "0.14"
+        , "elm-package"  =: "0.2"
+        , "elm-make"     =: "0.1"
+        , "elm-reactor"  =: "0.2"
+        , "elm-repl"     =: "0.4"
+        ]
+    ,
+      "0.13" =:
+        [ "Elm"         =: "0.13"
+        , "elm-reactor" =: "0.1"
+        , "elm-repl"    =: "0.3"
+        , "elm-get"     =: "0.1.3"
+        ]
+    ,
+      "0.12.3" =:
+        [ "Elm"        =: "0.12.3"
+        , "elm-server" =: "0.11.0.1"
+        , "elm-repl"   =: "0.2.2.1"
+        , "elm-get"    =: "0.1.2"
+        ]
+    ]
+
+
+main :: IO ()
+main =
+ do args <- getArgs
+    case args of
+      [version] | Map.member version configs ->
+          let artifactDirectory = "Elm-Platform" </> version
+              repos = configs Map.! version
+          in
+              makeRepos artifactDirectory version repos
+
+      _ ->
+        do hPutStrLn stderr $
+               "Expecting one of the following values as an argument:\n" ++
+               "    " ++ List.intercalate ", " (Map.keys configs)
+           exitFailure
+
+
+makeRepos :: FilePath -> String -> [(String, String)] -> IO ()
+makeRepos artifactDirectory version repos =
+ do createDirectoryIfMissing True artifactDirectory
+    setCurrentDirectory artifactDirectory
+    root <- getCurrentDirectory
+    mapM_ (uncurry (makeRepo root)) repos
+
+    cabal [ "update" ]
+
+    -- create a sandbox for installation
+    cabal [ "sandbox", "init" ]
+
+    -- add each of the sub-directories as a sandbox source
+    cabal ([ "sandbox", "add-source" ] ++ map fst repos)
+
+    -- install all of the packages together in order to resolve transitive dependencies robustly
+    -- (install the dependencies a bit more quietly than the elm packages)
+    cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ] ++ (if version <= "0.15.1" then [ "--constraint=fsnotify<0.2" ] else []) ++ map fst repos)
+    cabal ([ "install", "-j", "--ghc-options=\"-XFlexibleContexts\"" ] ++ filter (/= "elm-reactor") (map fst repos))
+
+    return ()
+
+makeRepo :: FilePath -> String -> String -> IO ()
+makeRepo root projectName version =
+  do  -- get the right version of the repo
+    git [ "clone", "https://github.com/elm-lang/" ++ projectName ++ ".git" ]
+    setCurrentDirectory projectName
+    git [ "checkout", version, "--quiet" ]
+
+    -- move back into the root
+    setCurrentDirectory root
+
+
+-- HELPER FUNCTIONS
+
+cabal :: [String] -> IO ExitCode
+cabal = rawSystem "cabal"
+
+git :: [String] -> IO ExitCode
+git = rawSystem "git"

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -2,7 +2,7 @@
 
 var processTitle = "elm-test"
 
-process.title = 'elm-test';
+process.title = processTitle;
 
 var compile    = require("node-elm-compiler").compile,
   suffix       = require("../elm-io-ports.js"),
@@ -11,8 +11,11 @@ var compile    = require("node-elm-compiler").compile,
   temp         = require("temp").track(), // Automatically cleans up temp files.
   util         = require("util"),
   _            = require("lodash"),
-  childProcess = require("child_process"),
-  elm          = require("elm");
+  childProcess = require("child_process");
+
+var elm = {
+  'elm-package': 'elm-package'
+};
 
 if (process.argv[2] == "init") {
   var copyTemplate = function(templateName) {
@@ -33,8 +36,9 @@ if (process.argv[2] == "init") {
       childProcess.execSync(elm["elm-package"] + " " + command + elmOptions, {stdio:[0,1,2]});
   }
 
-  execElmPackageSync("install deadfoxygrandpa/Elm-Test");
-  execElmPackageSync("install maxsnew/IO");
+  copyTemplate("elm-package.json");
+  execElmPackageSync("install deadfoxygrandpa/elm-test");
+  execElmPackageSync("install laszlopandy/elm-console");
   copyTemplate("TestRunner.elm");
   copyTemplate("Tests.elm");
   process.exit(0);
@@ -60,7 +64,7 @@ if (!fs.existsSync(testFile)) {
   process.exit(1);
 }
 
-temp.open('elm_test_', function(err, info) {
+temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
   var dest = info.path;
   var compileProcess = compile([testFile], {output: dest, spawn: spawnCompiler});
 

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -11,7 +11,8 @@ var compile    = require("node-elm-compiler").compile,
   temp         = require("temp").track(), // Automatically cleans up temp files.
   util         = require("util"),
   _            = require("lodash"),
-  childProcess = require("child_process");
+  childProcess = require("child_process"),
+  findup       = require("findup-sync");
 
 var elm = {
   'elm-package': 'elm-package'
@@ -102,23 +103,24 @@ temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
 
     console.log("Successfully compiled", testFile);
 
-    var runnerOpts = {stdio: ["pipe", "inherit", "inherit"]};
-    var runnerProcess = childProcess.spawn("node", [], runnerOpts);
+    // append suffix to temp file
+    fs.appendFile(dest, suffix, function(err){
+      if (err) throw(err);
 
-    runnerProcess.on('exit', function (exitCode) {
-      process.exit(exitCode);
+      console.log("Bootstrapped test script")
+
+      // add node_modules to NODE_PATH so the temporary file can require
+      // local modules
+      var pathToNodeModules = findup("node_modules");
+      process.env.NODE_PATH = _.compact([process.env.NODE_PATH, pathToNodeModules]).join(':');
+
+      var runnerProcess = childProcess.spawn("node", [dest], {stdio: 'inherit'});
+
+      runnerProcess.on('exit', function (exitCode) {
+        process.exit(exitCode);
+      });
+
+      console.log("Running tests...");
     });
-
-    var reader = fs.createReadStream(dest);
-
-    reader.on("end", function() {
-      runnerProcess.stdin.write(suffix);
-
-      runnerProcess.stdin.end();
-    })
-
-    reader.pipe(runnerProcess.stdin);
-
-    console.log("Running tests...");
   });
 });

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -17,6 +17,11 @@ var elm = {
   'elm-package': 'elm-package'
 };
 
+if (process.argv[2] == "--version") {
+  console.log(require(path.join(__dirname, "..", "package.json")).version);
+  process.exit(0);
+}
+
 if (process.argv[2] == "init") {
   var copyTemplate = function(templateName) {
     if (fs.existsSync(templateName)) {

--- a/bin/elm-test
+++ b/bin/elm-test
@@ -49,8 +49,9 @@ if (process.argv[2] == "init") {
   process.exit(0);
 }
 
-var testFile   = process.argv[2],
-    cwd        = __dirname;
+var testFile = process.argv[2],
+    cwd = __dirname,
+    pathToMake = undefined;
 
 function spawnCompiler(cmd, args, opts) {
   var compilerOpts = _.defaults({stdio: ["inherit", "pipe", "inherit"]}, opts);
@@ -60,7 +61,7 @@ function spawnCompiler(cmd, args, opts) {
 
 if (typeof testFile !== "string") {
   console.log("Usage: elm-test init [--yes]  # Create example tests\n");
-  console.log("Usage: elm-test TESTFILE  # Run tests\n");
+  console.log("Usage: elm-test TESTFILE [--compiler /path/to/compiler] # Run tests\n");
   process.exit(1);
 }
 
@@ -69,18 +70,27 @@ if (!fs.existsSync(testFile)) {
   process.exit(1);
 }
 
+if (process.argv[3] == "--compiler" || process.argv[3] == "-c") {
+  pathToMake = process.argv[4];
+
+  if (!pathToMake) {
+    console.error("The --compiler option must be given a path to an elm-make executable.");
+    process.exit(1);
+  }
+}
+
 temp.open({ prefix:'elm_test_', suffix:'.js' }, function(err, info) {
   var dest = info.path;
-  var compileProcess = compile([testFile], {output: dest, spawn: spawnCompiler});
-
-  console.log("Compiling", testFile);
+  var compileProcess = compile( [testFile],
+    {output: dest, spawn: spawnCompiler, pathToMake: pathToMake});
 
   compileProcess.stdout.setEncoding("utf8")
   compileProcess.stdout.on("data", function(data) {
     // Explicitly strip out the "Successfully generated" message.
     // This avoids the nasty compiler output message for the temp file, e.g.
     // "Successfully generated /var/folders/f2/afd9fg0acfg32/elm_test_3423940"
-    if ((typeof data === "string") && !data.match(/^Successfully generated /)) {
+    // Also strip out "Success! Compiled 1 module."
+    if ((typeof data === "string") && !/^Success/.test(data)) {
       console.log(data);
     }
   });

--- a/ci.sh
+++ b/ci.sh
@@ -6,7 +6,7 @@ echo "$0: Installing elm-test..."
 npm install --global
 
 echo "$0: Testing elm-test init..."
-mkdir tmp
+mkdir -p tmp
 cd tmp
 elm-test init --yes
 elm-test TestRunner.elm | tee test.log

--- a/ci.sh
+++ b/ci.sh
@@ -2,30 +2,44 @@
 
 set -e
 
+function assertTestFailure() {
+  elm-package install --yes
+  elm-test "$1" | tee "$1".test.log
+  if test ${PIPESTATUS[0]} -ne 1; then
+    echo "$0: ERROR: $1: Expected tests to fail" >&2
+    exit 1
+  fi
+}
+
+function assertTestSuccess() {
+  elm-package install --yes
+  elm-test "$1" | tee "$1".test.log
+  if test ${PIPESTATUS[0]} -ne 0; then
+    echo "$0: ERROR: $1: Expected tests to pass" >&2
+    exit 1
+  fi
+}
+
 echo "$0: Installing elm-test..."
 npm install --global
+
+echo "$0: Testing examples..."
+cd examples
+assertTestSuccess PassingTests.elm
+assertTestFailure FailingTests.elm
+cd ..
 
 echo "$0: Testing elm-test init..."
 mkdir -p tmp
 cd tmp
 elm-test init --yes
-elm-test TestRunner.elm | tee test.log
-if test ${PIPESTATUS[0]} -ne 1; then
-  echo "$0: ERROR: Expected example tests to fail" >&2
-  exit 1
-fi
+assertTestFailure TestRunner.elm
+# delete the failing tests and the comma on the preceding line
+ex -c 'g/should fail/' -c 'd' -c 'g-1' -c 's/,$//' -c 'wq' Tests.elm
+rm -Rf elm-stuff
+assertTestSuccess TestRunner.elm
 cd ..
 rm -Rf tmp
-
-echo "$0: Testing examples..."
-cd examples
-elm-package install --yes
-elm-test Test.elm | tee test.log
-if test ${PIPESTATUS[0]} -ne 1; then
-  echo "$0: ERROR: Expected example tests to fail" >&2
-  exit 1
-fi
-cd ..
 
 echo ""
 echo "$0: Everything looks good!"

--- a/ci.sh
+++ b/ci.sh
@@ -23,6 +23,9 @@ function assertTestSuccess() {
 echo "$0: Installing elm-test..."
 npm install --global
 
+echo "$0: Verifying installed elm-test version..."
+elm-test --version
+
 echo "$0: Testing examples..."
 cd examples
 assertTestSuccess PassingTests.elm

--- a/elm-io-ports.js
+++ b/elm-io-ports.js
@@ -2,7 +2,45 @@
 module.exports =
   "(function(){\n" +
   "    window = {Date: Date};\n" +
+  "    var stdin = process.stdin;\n" +
+  "    var fs    = require('fs');\n" +
   "    if (typeof Elm === \"undefined\") { throw \"elm-io config error: Elm is not defined. Make sure you call elm-io with a real Elm output file\"}\n" +
   "    if (typeof Elm.Main === \"undefined\" ) { throw \"Elm.Main is not defined, make sure your module is named Main.\" };\n" +
-  "    var worker = Elm.worker(Elm.Main);\n" +
+  "    var worker = Elm.worker(Elm.Main\n" +
+  "                            , {responses: null }\n" +
+  "                           );\n" +
+  "    var just = function(v) {\n" +
+  "        return { 'Just': v};\n" +
+  "    }\n" +
+  "    var handle = function(request) {\n" +
+  "        \n" +
+  "        switch(request.ctor) {\n" +
+  "        case 'Put':\n" +
+  "            process.stdout.write(request.val);\n" +
+  "            break;\n" +
+  "        case 'Get':\n" +
+  "            stdin.resume();\n" +
+  "            break;\n" +
+  "        case 'Exit':\n" +
+  "            process.exit(request.val);\n" +
+  "            break;\n" +
+  "        case 'WriteFile':\n" +
+  "            fs.writeFileSync(request.file, request.content);\n" +
+  "            break;\n" +
+  "        }\n" +
+  "    }\n" +
+  "    var handler = function(reqs) {\n" +
+  "        for (var i = 0; i < reqs.length; i++) {\n" +
+  "            handle(reqs[i]);\n" +
+  "        }\n" +
+  "        if (reqs.length > 0 && reqs[reqs.length - 1].ctor !== 'Get') {\n" +
+  "            worker.ports.responses.send(just(\"\"));\n" +
+  "        }\n" +
+  "    }\n" +
+  "    worker.ports.requests.subscribe(handler);\n" +
+  "    stdin.on('data', function(chunk) {\n" +
+  "        stdin.pause();\n" +
+  "        worker.ports.responses.send(just(chunk.toString()));\n" +
+  "    });\n" +
+  "    worker.ports.responses.send(null);\n" +
   "})();\n";

--- a/elm-io-ports.js
+++ b/elm-io-ports.js
@@ -1,45 +1,7 @@
-/* Implementation from: https://raw.githubusercontent.com/maxsnew/IO/master/elm-io.sh */
+/* Implementation from: https://raw.githubusercontent.com/laszlopandy/elm-console/1.0.2/elm-io.sh */
 module.exports =
   "(function(){\n" +
-  "    window = {Date: Date};\n" +
-  "    var stdin = process.stdin;\n" +
-  "    var fs    = require('fs');\n" +
-  "    var worker = Elm.worker(Elm.Main, {responses: null });\n" +
-  "    var just = function(v) {\n" +
-  "        return { 'Just': v};\n" +
-  "    }\n" +
-  "    var handle = function(request) {\n" +
-  "        switch(request.ctor) {\n" +
-  "        case 'Put':\n" +
-  "            process.stdout.write(request.val);\n" +
-  "            break;\n" +
-  "        case 'Get':\n" +
-  "            stdin.resume();\n" +
-  "            break;\n" +
-  "        case 'Exit':\n" +
-  "            process.exit(request.val);\n" +
-  "            break;\n" +
-  "        case 'WriteFile':\n" +
-  "            fs.writeFileSync(request.file, request.content);\n" +
-  "            break;\n" +
-  "        }\n" +
-  "    }\n" +
-  "    var handler = function(reqs) {\n" +
-  "        for (var i = 0; i < reqs.length; i++) {\n" +
-  "            handle(reqs[i]);\n" +
-  "        }\n" +
-  "        if (reqs.length > 0 && reqs[reqs.length - 1].ctor !== 'Get') {\n" +
-  "            worker.ports.responses.send(just(\"\"));\n" +
-  "        }\n" +
-  "    }\n" +
-  "    worker.ports.requests.subscribe(handler);\n" +
-  "    \n" +
-  "    // Read\n" +
-  "    stdin.on('data', function(chunk) {\n" +
-  "        stdin.pause();\n" +
-  "        worker.ports.responses.send(just(chunk.toString()));\n" +
-  "    })\n" +
-  "\n" +
-  "    // Start msg\n" +
-  "    worker.ports.responses.send(null);\n" +
+  "    if (typeof Elm === \"undefined\") { throw \"elm-io config error: Elm is not defined. Make sure you call elm-io with a real Elm output file\"}\n" +
+  "    if (typeof Elm.Main === \"undefined\" ) { throw \"Elm.Main is not defined, make sure your module is named Main.\" };\n" +
+  "    var worker = Elm.worker(Elm.Main);\n" +
   "})();\n";

--- a/elm-io-ports.js
+++ b/elm-io-ports.js
@@ -1,45 +1,8 @@
-/* Implementation from: https://raw.githubusercontent.com/maxsnew/IO/master/elm-io.sh */
+/* Implementation from: https://github.com/laszlopandy/elm-console/blob/master/elm-io.sh */
 module.exports =
   "(function(){\n" +
   "    window = {Date: Date};\n" +
-  "    var stdin = process.stdin;\n" +
-  "    var fs    = require('fs');\n" +
-  "    var worker = Elm.worker(Elm.Main, {responses: null });\n" +
-  "    var just = function(v) {\n" +
-  "        return { 'Just': v};\n" +
-  "    }\n" +
-  "    var handle = function(request) {\n" +
-  "        switch(request.ctor) {\n" +
-  "        case 'Put':\n" +
-  "            process.stdout.write(request.val);\n" +
-  "            break;\n" +
-  "        case 'Get':\n" +
-  "            stdin.resume();\n" +
-  "            break;\n" +
-  "        case 'Exit':\n" +
-  "            process.exit(request.val);\n" +
-  "            break;\n" +
-  "        case 'WriteFile':\n" +
-  "            fs.writeFileSync(request.file, request.content);\n" +
-  "            break;\n" +
-  "        }\n" +
-  "    }\n" +
-  "    var handler = function(reqs) {\n" +
-  "        for (var i = 0; i < reqs.length; i++) {\n" +
-  "            handle(reqs[i]);\n" +
-  "        }\n" +
-  "        if (reqs.length > 0 && reqs[reqs.length - 1].ctor !== 'Get') {\n" +
-  "            worker.ports.responses.send(just(\"\"));\n" +
-  "        }\n" +
-  "    }\n" +
-  "    worker.ports.requests.subscribe(handler);\n" +
-  "    \n" +
-  "    // Read\n" +
-  "    stdin.on('data', function(chunk) {\n" +
-  "        stdin.pause();\n" +
-  "        worker.ports.responses.send(just(chunk.toString()));\n" +
-  "    })\n" +
-  "\n" +
-  "    // Start msg\n" +
-  "    worker.ports.responses.send(null);\n" +
+  "    if (typeof Elm === \"undefined\") { throw \"elm-io config error: Elm is not defined. Make sure you call elm-io with a real Elm output file\"}\n" +
+  "    if (typeof Elm.Main === \"undefined\" ) { throw \"Elm.Main is not defined, make sure your module is named Main.\" };\n" +
+  "    var worker = Elm.worker(Elm.Main);\n" +
   "})();\n";

--- a/elm-io-ports.js
+++ b/elm-io-ports.js
@@ -1,19 +1,14 @@
-/* Implementation from: https://raw.githubusercontent.com/laszlopandy/elm-console/1.0.2/elm-io.sh */
+/* Implementation from: https://raw.githubusercontent.com/maxsnew/IO/master/elm-io.sh */
 module.exports =
   "(function(){\n" +
   "    window = {Date: Date};\n" +
   "    var stdin = process.stdin;\n" +
   "    var fs    = require('fs');\n" +
-  "    if (typeof Elm === \"undefined\") { throw \"elm-io config error: Elm is not defined. Make sure you call elm-io with a real Elm output file\"}\n" +
-  "    if (typeof Elm.Main === \"undefined\" ) { throw \"Elm.Main is not defined, make sure your module is named Main.\" };\n" +
-  "    var worker = Elm.worker(Elm.Main\n" +
-  "                            , {responses: null }\n" +
-  "                           );\n" +
+  "    var worker = Elm.worker(Elm.Main, {responses: null });\n" +
   "    var just = function(v) {\n" +
   "        return { 'Just': v};\n" +
   "    }\n" +
   "    var handle = function(request) {\n" +
-  "        \n" +
   "        switch(request.ctor) {\n" +
   "        case 'Put':\n" +
   "            process.stdout.write(request.val);\n" +
@@ -38,9 +33,13 @@ module.exports =
   "        }\n" +
   "    }\n" +
   "    worker.ports.requests.subscribe(handler);\n" +
+  "    \n" +
+  "    // Read\n" +
   "    stdin.on('data', function(chunk) {\n" +
   "        stdin.pause();\n" +
   "        worker.ports.responses.send(just(chunk.toString()));\n" +
-  "    });\n" +
+  "    })\n" +
+  "\n" +
+  "    // Start msg\n" +
   "    worker.ports.responses.send(null);\n" +
   "})();\n";

--- a/elm-io-ports.js
+++ b/elm-io-ports.js
@@ -1,6 +1,7 @@
 /* Implementation from: https://raw.githubusercontent.com/laszlopandy/elm-console/1.0.2/elm-io.sh */
 module.exports =
   "(function(){\n" +
+  "    window = {Date: Date};\n" +
   "    if (typeof Elm === \"undefined\") { throw \"elm-io config error: Elm is not defined. Make sure you call elm-io with a real Elm output file\"}\n" +
   "    if (typeof Elm.Main === \"undefined\" ) { throw \"Elm.Main is not defined, make sure your module is named Main.\" };\n" +
   "    var worker = Elm.worker(Elm.Main);\n" +

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -1,0 +1,25 @@
+module Main where
+
+import Basics exposing (..)
+import Signal exposing (..)
+
+import ElmTest.Assertion as A exposing (assertEqual, assert)
+import ElmTest.Run as R
+import ElmTest.Runner.Console exposing (runDisplay)
+import ElmTest.Test exposing (..)
+import Console exposing (IO, run)
+import Task
+import String
+
+tests : Test
+tests = suite "A Test Suite"
+        [ test "Addition" (assertEqual (3 + 7) 10)
+        , test "String.left" (assertEqual "a" (String.left 1 "abcdefg"))
+        , test "This test should fail" (assert False)
+        ]
+
+console : IO ()
+console = runDisplay tests
+
+port runner : Signal (Task.Task x ())
+port runner = run console

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -3,10 +3,7 @@ module Main where
 import Basics exposing (..)
 import Signal exposing (..)
 
-import ElmTest.Assertion as A exposing (assertEqual, assert)
-import ElmTest.Run as R
-import ElmTest.Runner.Console exposing (runDisplay)
-import ElmTest.Test exposing (..)
+import ElmTest exposing (..)
 import Console exposing (IO, run)
 import Task
 import String
@@ -19,7 +16,7 @@ tests = suite "A Test Suite"
         ]
 
 console : IO ()
-console = runDisplay tests
+console = consoleRunner tests
 
 port runner : Signal (Task.Task x ())
 port runner = run console

--- a/examples/PassingTests.elm
+++ b/examples/PassingTests.elm
@@ -3,10 +3,7 @@ module Main where
 import Basics exposing (..)
 import Signal exposing (..)
 
-import ElmTest.Assertion as A exposing (assertEqual, assert)
-import ElmTest.Run as R
-import ElmTest.Runner.Console exposing (runDisplay)
-import ElmTest.Test exposing (..)
+import ElmTest exposing (..)
 import Console exposing (IO, run)
 import Task
 import String
@@ -18,7 +15,7 @@ tests = suite "A Test Suite"
         ]
 
 console : IO ()
-console = runDisplay tests
+console = consoleRunner tests
 
 port runner : Signal (Task.Task x ())
 port runner = run console

--- a/examples/PassingTests.elm
+++ b/examples/PassingTests.elm
@@ -7,23 +7,18 @@ import ElmTest.Assertion as A exposing (assertEqual, assert)
 import ElmTest.Run as R
 import ElmTest.Runner.Console exposing (runDisplay)
 import ElmTest.Test exposing (..)
-import IO.IO exposing (..)
-import IO.Runner exposing (Request, Response)
-import IO.Runner as Run
-
+import Console exposing (IO, run)
+import Task
 import String
 
 tests : Test
 tests = suite "A Test Suite"
         [ test "Addition" (assertEqual (3 + 7) 10)
         , test "String.left" (assertEqual "a" (String.left 1 "abcdefg"))
-        , test "This test should fail" (assert False)
         ]
 
 console : IO ()
 console = runDisplay tests
 
-port requests : Signal Request
-port requests = Run.run responses console
-
-port responses : Signal Response
+port runner : Signal (Task.Task x ())
+port runner = run console

--- a/examples/Test.elm
+++ b/examples/Test.elm
@@ -21,5 +21,7 @@ tests = suite "A Test Suite"
 console : IO ()
 console = runDisplay tests
 
-port runner : Signal (Task.Task x ())
-port runner = Console.run console
+port requests : Signal Request
+port requests = Run.run responses console
+
+port responses : Signal Response

--- a/examples/Test.elm
+++ b/examples/Test.elm
@@ -7,8 +7,10 @@ import ElmTest.Assertion as A exposing (assertEqual, assert)
 import ElmTest.Run as R
 import ElmTest.Runner.Console exposing (runDisplay)
 import ElmTest.Test exposing (..)
-import Console exposing (..)
-import Task
+import IO.IO exposing (..)
+import IO.Runner exposing (Request, Response)
+import IO.Runner as Run
+
 import String
 
 tests : Test

--- a/examples/Test.elm
+++ b/examples/Test.elm
@@ -7,10 +7,8 @@ import ElmTest.Assertion as A exposing (assertEqual, assert)
 import ElmTest.Run as R
 import ElmTest.Runner.Console exposing (runDisplay)
 import ElmTest.Test exposing (..)
-import IO.IO exposing (..)
-import IO.Runner exposing (Request, Response)
-import IO.Runner as Run
-
+import Console exposing (..)
+import Task
 import String
 
 tests : Test
@@ -23,7 +21,5 @@ tests = suite "A Test Suite"
 console : IO ()
 console = runDisplay tests
 
-port requests : Signal Request
-port requests = Run.run responses console
-
-port responses : Signal Response
+port runner : Signal (Task.Task x ())
+port runner = Console.run console

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -8,7 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "deadfoxygrandpa/elm-test": "2.0.0 <= v < 3.0.0",
+        "deadfoxygrandpa/elm-test": "2.0.0 <= v < 4.0.0",
         "elm-lang/core": "2.0.0 <= v < 4.0.0",
         "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"
     },

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -2,15 +2,15 @@
     "version": "1.0.0",
     "summary": "Sample Elm Test",
     "repository": "https://github.com/rtfeldman/node-elm-test.git",
-    "license": "Apache-2.0",
+    "license": "BSD-3-Clause",
     "source-directories": [
         "."
     ],
     "exposed-modules": [],
     "dependencies": {
-        "deadfoxygrandpa/Elm-Test": "1.0.2 <= v < 2.0.0",
-        "elm-lang/core": "2.0.0 <= v < 4.0.0",
-        "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"
+        "elm-lang/core": "2.0.0 <= v < 3.0.0",
+        "deadfoxygrandpa/Elm-Test": "1.0.4 <= v <= 1.0.4",
+        "maxsnew/IO": "1.0.1 <= v <= 1.0.1"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.15.0 <= v < 0.16.0"
 }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -8,9 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "deadfoxygrandpa/Elm-Test": "1.0.4 <= v <= 1.0.4",
-        "maxsnew/IO": "1.0.1 <= v <= 1.0.1"
+        "deadfoxygrandpa/elm-test": "2.0.0 <= v < 3.0.0",
+        "elm-lang/core": "2.0.0 <= v < 4.0.0",
+        "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.15.0 <= v < 0.17.0"
 }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -8,9 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "2.0.1 <= v < 3.0.0",
-        "maxsnew/IO": "1.0.0 <= v < 2.0.0",
-        "deadfoxygrandpa/Elm-Test": "1.0.3 <= v < 2.0.0"
+        "deadfoxygrandpa/Elm-Test": "1.0.2 <= v < 2.0.0",
+        "elm-lang/core": "2.0.0 <= v < 4.0.0",
+        "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.16.0-beta2",
+  "version": "0.16.0",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.16.0-beta",
+  "version": "0.16.0-beta2",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   },
   "homepage": "https://github.com/rtfeldman/node-elm-test#readme",
   "dependencies": {
-    "fs-extra": "0.23.1",
+    "fs-extra": "0.26.2",
     "lodash": "3.10.1",
-    "node-elm-compiler": "1.0.1",
-    "temp": "0.8.1"
+    "node-elm-compiler": "2.0.0",
+    "temp": "0.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=0.10.0"
   },
   "scripts": {
     "test": "./ci.sh"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,9 @@
   },
   "homepage": "https://github.com/rtfeldman/node-elm-test#readme",
   "dependencies": {
-    "elm": "2.0.0",
     "fs-extra": "0.23.1",
-    "lodash": "3.9.3",
-    "node-elm-compiler": "0.4.0+elm-0.15.1",
+    "lodash": "3.10.1",
+    "node-elm-compiler": "1.0.0",
     "temp": "0.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "elm-test",
-  "version": "0.6.5",
+  "version": "0.16.0-beta",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "scripts": {
     "test": "./ci.sh"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "fs-extra": "0.23.1",
     "lodash": "3.10.1",
-    "node-elm-compiler": "1.0.0",
+    "node-elm-compiler": "1.0.1",
     "temp": "0.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {
@@ -31,6 +31,7 @@
     "fs-extra": "0.26.2",
     "lodash": "3.10.1",
     "node-elm-compiler": "2.0.0",
-    "temp": "0.8.3"
+    "temp": "0.8.3",
+    "findup-sync": "0.4.3"
   }
 }

--- a/templates/TestRunner.elm
+++ b/templates/TestRunner.elm
@@ -3,16 +3,13 @@ module Main where
 import Signal exposing (Signal)
 
 import ElmTest.Runner.Console exposing (runDisplay)
-import IO.IO exposing (IO)
-import IO.Runner exposing (Request, Response)
-import IO.Runner as Run
+import Console exposing (IO)
+import Task
 
 import Tests
 
 console : IO ()
 console = runDisplay Tests.all
 
-port requests : Signal Request
-port requests = Run.run responses console
-
-port responses : Signal Response
+port runner : Signal (Task.Task x ())
+port runner = Console.run console

--- a/templates/TestRunner.elm
+++ b/templates/TestRunner.elm
@@ -3,13 +3,16 @@ module Main where
 import Signal exposing (Signal)
 
 import ElmTest.Runner.Console exposing (runDisplay)
-import Console exposing (IO)
-import Task
+import IO.IO exposing (IO)
+import IO.Runner exposing (Request, Response)
+import IO.Runner as Run
 
 import Tests
 
 console : IO ()
 console = runDisplay Tests.all
 
-port runner : Signal (Task.Task x ())
-port runner = Console.run console
+port requests : Signal Request
+port requests = Run.run responses console
+
+port responses : Signal Response

--- a/templates/TestRunner.elm
+++ b/templates/TestRunner.elm
@@ -3,16 +3,13 @@ module Main where
 import Signal exposing (Signal)
 
 import ElmTest.Runner.Console exposing (runDisplay)
-import IO.IO exposing (IO)
-import IO.Runner exposing (Request, Response)
-import IO.Runner as Run
+import Console exposing (IO, run)
+import Task
 
 import Tests
 
 console : IO ()
 console = runDisplay Tests.all
 
-port requests : Signal Request
-port requests = Run.run responses console
-
-port responses : Signal Response
+port runner : Signal (Task.Task x ())
+port runner = run console

--- a/templates/TestRunner.elm
+++ b/templates/TestRunner.elm
@@ -2,14 +2,14 @@ module Main where
 
 import Signal exposing (Signal)
 
-import ElmTest.Runner.Console exposing (runDisplay)
+import ElmTest exposing (consoleRunner)
 import Console exposing (IO, run)
 import Task
 
 import Tests
 
 console : IO ()
-console = runDisplay Tests.all
+console = consoleRunner Tests.all
 
 port runner : Signal (Task.Task x ())
 port runner = run console

--- a/templates/Tests.elm
+++ b/templates/Tests.elm
@@ -1,7 +1,6 @@
 module Tests where
 
-import ElmTest.Assertion exposing (..)
-import ElmTest.Test exposing (..)
+import ElmTest exposing (..)
 
 import String
 

--- a/templates/elm-package.json
+++ b/templates/elm-package.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.16.0 <= v < 0.17.0"
+}

--- a/templates/elm-package.json
+++ b/templates/elm-package.json
@@ -8,7 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "2.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.15.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
when using elm-test with node 7 (not node 6), with stderr redirection, elm-test raises exceptions.

avoiding pipeing the test contents into the child node process fixes these problems.

upstream bug report here https://github.com/nodejs/node/issues/11257