### PR TITLE
Fix displayed test path variable name when a module fails to compile

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -285,7 +285,7 @@ function compileAllTests(testFilePaths) {
 
     compileProcess.on('close', function(exitCode) {
       if (exitCode !== 0) {
-        reject("Compilation failed while attempting to build " + generatedTestFilePaths.join(" "));
+        reject("Compilation failed while attempting to build " + testFilePaths.join(" "));
       } else {
         resolve();
       }


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/node-test-runner/issues/114

Before
```
Unhandled exception while running the tests: ReferenceError: generatedTestFilePaths is not defined
    at ChildProcess.<anonymous> (/Users/erik/code/node-test-runner/bin/elm-test:288:66)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:194:7)
    at maybeClose (internal/child_process.js:899:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
```

After
```
Compilation failed while attempting to build /Users/erik/code/project/tests/FooTests.elm
```