### PR TITLE
Hoist infoLog function up to the top level to fix broken references

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -294,11 +294,6 @@ function compileAllTests(testFilePaths) {
 }
 
 function generatePackageJson(filePathArgs) {
-  function infoLog(msg) {
-    if (report === "chalk") {
-      console.log(msg);
-    }
-  }
 
   // TODO we don't want to do this every single time. Instead,
   // verify that the generated elm-package.json is there, with the
@@ -465,6 +460,12 @@ if (args.report === "chalk" || args.report === "json" || args.report === "junit"
     process.exit(1);
 } else {
   report = "chalk";
+}
+
+function infoLog(msg) {
+  if (report === "chalk") {
+    console.log(msg);
+  }
 }
 
 function spawnCompiler(cmd, args, opts) {


### PR DESCRIPTION
I'm getting this exception when I run `--watch` mode:
```
ReferenceError: infoLog is not defined
    at generateAndRunTests (/Users/erik/code/node-test-runner/bin/elm-test:432:5)
    at /Users/erik/code/node-test-runner/bin/elm-test:261:9
```

It looks like this function was originally at the top level but got wrapped up in another function at some point. It seemed like it was kind of floating alone, so I moved it down next to where the flag is handled.