### PR TITLE
Alpha fixes

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -222,19 +222,21 @@ function runElmTest() {
     process.exit(0);
   }
 
+  function globify(filename) {
+    return glob.sync(filename, {nocase: true, ignore: "**/elm-stuff/**", nodir: false} );
+  }
+
   // TODO on macOS if you give it a glob as its last argument, Node translates
   // that into a list of file paths. Do we get the same result on Windows?
   // If not, we need to do custom glob handling there.
   var filePathArgs = args._.length > 0 ? args._ : [];
-  var testFilePaths = _.flatMap(
-    (filePathArgs.length > 0 ? filePathArgs :
-      glob.sync(
-        path.resolve(Runner.findNearestElmPackageDir(process.cwd())) + "/test?(s)/**/*.elm",
-        {nocase: true, ignore: "**/elm-stuff/**", nodir: false}
-      )
-    ),
-    resolveFilePath
-  );
+  var globs = _.flatMap(
+      (filePathArgs.length > 0
+        ? filePathArgs
+        : [path.resolve(Runner.findNearestElmPackageDir(process.cwd()) + "/test?(s)/**/*.elm")]
+      ),
+    globify);
+  var testFilePaths = _.flatMap(globs, resolveFilePath);
 
   if (testFilePaths.length === 0) {
     var errorMessage =

--- a/example/tests/TestsFailing.elm
+++ b/example/tests/TestsFailing.elm
@@ -1,4 +1,4 @@
-module FailingTests exposing (..)
+module TestsFailing exposing (..)
 
 import String
 import Expect

--- a/example/tests/TestsFailing.elm
+++ b/example/tests/TestsFailing.elm
@@ -18,7 +18,7 @@ ultimateTest =
 
 someTodos : Test
 someTodos =
-    Test.describe "you should not see these in normal output, because there are non-TODO failures"
+    Test.describe "you should not see these in normal output, because there are non-Todo failures"
         [ Test.todo "write a test here"
         , Test.todo "write a second test here"
         , Test.todo "write a third test here"

--- a/example/tests/TestsPassing.elm
+++ b/example/tests/TestsPassing.elm
@@ -1,4 +1,4 @@
-module PassingTests exposing (..)
+module TestsPassing exposing (..)
 
 import Expect
 import Test exposing (Test, test)

--- a/example/tests/elm-package.json
+++ b/example/tests/elm-package.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "source-directories": [
         "../src",
-        "../../elm-test/src/",
+        "../../../elm-test/src/",
         "."
     ],
     "exposed-modules": [],

--- a/lib/init.js
+++ b/lib/init.js
@@ -48,7 +48,7 @@ function modifyElmPackage(elmPackageJson) {
     }
   ).concat(["."])
   // TODO REMOVE THIS
-  .concat(["../../elm-test/src/"]);
+  .concat(["../../../elm-test/src/"]);
 
   var deps = Object.assign(
     {}, templateElmPackage.dependencies, elmPackageJson.dependencies

--- a/src/Test/Reporter/Chalk.elm
+++ b/src/Test/Reporter/Chalk.elm
@@ -210,8 +210,8 @@ reportSummary duration autoFail results =
                     ]
 
         todoStats =
-            -- Print stats for TODOs if there are any,
-            --but don't print details unless only TODOs remain
+            -- Print stats for Todos if there are any,
+            --but don't print details unless only Todos remain
             case List.length todos of
                 0 ->
                     []

--- a/templates/tests/elm-package.json
+++ b/templates/tests/elm-package.json
@@ -4,7 +4,7 @@
     "repository": "https://github.com/elm-community/elm-test.git",
     "license": "BSD-3-Clause",
     "source-directories": [
-        "../../elm-test/src/",
+        "../../../elm-test/src/",
         "."
     ],
     "exposed-modules": [],

--- a/tests/OneTodoFailing.elm
+++ b/tests/OneTodoFailing.elm
@@ -6,7 +6,7 @@ import Test exposing (..)
 
 suite : Test
 suite =
-    Test.describe "TODO tests"
+    Test.describe "Todo tests"
         [ Test.todo "write a test here"
         ]
 

--- a/tests/SeveralTodosFailing.elm
+++ b/tests/SeveralTodosFailing.elm
@@ -6,7 +6,7 @@ import Test exposing (..)
 
 someTodos : Test
 someTodos =
-    Test.describe "three TODO tests"
+    Test.describe "three Todo tests"
         [ Test.todo "write a test here"
         , Test.todo "write a second test here"
         , Test.todo "write a third test here"

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -46,8 +46,8 @@ echo('### Testing elm-test on example/');
 
 cd('example');
 
-assertTestSuccess(path.join("tests", "PassingTests.*"));
-assertTestFailure(path.join("tests", "Fail*"));
+assertTestSuccess(path.join("tests", "TestsPass*"));
+assertTestFailure(path.join("tests", "TestsFail*"));
 assertTestFailure();
 
 ls("tests/*.elm").forEach(function(testToRun) {

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -20,7 +20,7 @@ function run(testFile) {
   }
 }
 
-function asserttestfailure(testfile) {
+function assertTestFailure(testfile) {
   var code = run(testfile);
   if (code < 2) {
     exec('echo ' + filename + ': error: ' + (testfile ? testfile + ': ' : '') + 'expected tests to fail >&2');


### PR DESCRIPTION
I made both `elm-test '**/*.elm'` and `elm-test **/*.elm` work on macOS.

If I'm correct that Bash 3.x is passing the former, I suspect this will fix https://github.com/rtfeldman/node-test-runner/issues/116!