### PR TITLE
Ensure that an error is raised for invalid test modules

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -348,31 +348,28 @@ function findTests(elmPackageJsonPath, testFilePaths) {
 // Check for modules where the name doesn't match the filename.
 // elm-make won't get a chance to detect this; they'll be filtered out first.
 function verifyModules(filePaths) {
-  return new Promise(function(resolve, reject) {
-    return Promise.all(
-      _.map(filePaths, function(filePath) {
-        return firstline(filePath).then(function(line) {
-          matches = line.match(/^module\s+(\S+)\s*/);
+  return Promise.all(
+    _.map(filePaths, function(filePath) {
+      return firstline(filePath).then(function(line) {
+        matches = line.match(/^module\s+(\S+)\s*/);
 
-          if (matches) {
-            var moduleName = matches[1];
-            var testModulePaths = moduleFromTestName(moduleName);
-            var modulePath = moduleFromFilePath(filePath);
+        if (matches) {
+          var moduleName = matches[1];
+          var testModulePaths = moduleFromTestName(moduleName);
+          var modulePath = moduleFromFilePath(filePath);
 
-            // A module path matches if it lines up completely with a known one.
-            if (!testModulePaths.every(function(testModulePath, index) {
-              return testModulePath === modulePath[index];
-            })) {
-              reject(filePath + " has a module declaration of \"" + moduleName + "\" - which does not match its filename!");
-            }
-          } else {
-            reject(filePath + " has an invalid module declaration. Check the first line of the file and make sure it has a valid module declaration there!");
+          // A module path matches if it lines up completely with a known one.
+          if (!testModulePaths.every(function(testModulePath, index) {
+            return testModulePath === modulePath[index];
+          })) {
+            return Promise.reject(filePath + " has a module declaration of \"" + moduleName + "\" - which does not match its filename!");
           }
-          resolve(line);
-        }).catch(reject);
-      })
-    ).then(resolve).catch(reject);
-  });
+        } else {
+          return Promise.reject(filePath + " has an invalid module declaration. Check the first line of the file and make sure it has a valid module declaration there!");
+        }
+      });
+    })
+  )
 }
 
 function filterExposing(pathAndModule) {


### PR DESCRIPTION
If multiple files are being tested and a valid one is checked before an invalid one is found, this [`resolve` call](https://github.com/rtfeldman/node-test-runner/pull/120/files#diff-b3b53682a18f203ac8d29b0e277cad26R371) causes the overall promise to succeed.

Simply removing the `resolve(line)` seems reasonably effective, but also seems to kind of subvert good promise hygiene.