### PR TITLE
give exit code 1 when there are unhandled exceptions

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -12,8 +12,10 @@ process.on('uncaughtException', function(error) {
     // initialization code to something like `Elm.Test.Generated.Main.fullscreen()`]"
     console.error("Error starting the node-test-runner.");
     console.error("Please check your Javascript 'elm-test' and Elm 'node-test-runner' package versions are compatible");
+    process.exit(1);
   } else {
     console.error("Unhandled exception while running the tests:", error);
+    process.exit(1);
   }
 });
 


### PR DESCRIPTION
# What this does

Just like for all of the other error cases in the test runner, we should give a failure code when the tests don't pass. This adds `process.exit(1)` to uncaughtException branches

# How we got bit

In Jenkins pipeline we're looking out for exit codes to break the build. In our particular case, hitting Debug.crash was masking other real test failures because elm-test was dying but reporting exit code 0 which caused CI to secretly pass. It should die and tell everyone it dies.

