### PR TITLE
Allow `exposing` to appear on a line by itself

### DIFF
--- a/lib/finder.js
+++ b/lib/finder.js
@@ -49,24 +49,24 @@ var stripComments = function(line, isInComment) {
 
     // when there's no comment chars
     if (startIndex === -1 && endIndex === -1) {
-      return { 
-        line: isInComment ? "" : line, 
+      return {
+        line: isInComment ? "" : line,
         isInComment: isInComment
       };
     }
 
     // when there's a start and end
-    if (startIndex > -1 && endIndex > -1) { 
+    if (startIndex > -1 && endIndex > -1) {
       line = line.substr(0, startIndex) + line.substr(endIndex + 2);
       continue;
     }
 
     // when there's a start, but no end
     if (startIndex > -1 ) return { line : line.substr(0, startIndex), isInComment: true };
-    
+
     // when there's an end, but no start
     if (endIndex > -1 && isInComment) return { line: line.substr(endIndex + 2), isInComment: false };
-  } 
+  }
 
   return { line: "", isInComment: isInComment };
 }
@@ -80,7 +80,7 @@ var splitExposedFunctions = function(exposingLine) {
 };
 
 var isAModuleLine = function(line){
-  return line.startsWith('module ')
+  return line.startsWith('module')
     || line.startsWith('port module')
     || line.startsWith('effect module');
 };
@@ -95,7 +95,7 @@ function Parser(){
 
   // if we're done parsing
   var parsingDone = false;
-  
+
   // if the module line has been read
   var hasModuleLineBeenRead = false;
 
@@ -114,7 +114,7 @@ function Parser(){
 
   this.parseLine = function(line){
     if (parsingDone) return;
-    
+
     var whereWeUpTo = stripComments(line, isInComment);
     isInComment = whereWeUpTo.isInComment;
     line = whereWeUpTo.line.trim();
@@ -129,7 +129,7 @@ function Parser(){
       isReadingModuleName = true;
 
       if (line.length === 0) return;
-    } 
+    }
 
     // if we manage to find content before the module line,
     // something is wrong - so exit
@@ -145,8 +145,6 @@ function Parser(){
 
       // if we haven't found exposing yet
       if (exposingIndex === -1) {
-        if (line.length > 0) parsingDone = true;
-
         return;
       };
 
@@ -165,17 +163,17 @@ function Parser(){
       openBracketsSeen += 1;
       isReadingExports = false;
       isBetweenBrackets = true;
-      line = line.substr(firstBracket + 1); 
+      line = line.substr(firstBracket + 1);
     }
 
     // if we're before the final bracket
     if (isBetweenBrackets) {
       var newOpenBracketsSeen = line.split('(').length;
       var newCloseBracketsSeen = line.split(')').length;
-      
+
       closedBracketsSeen += newCloseBracketsSeen;
       openBracketsSeen += newOpenBracketsSeen;
-      
+
       data += line;
 
       if (closedBracketsSeen === openBracketsSeen){


### PR DESCRIPTION
Additionally, allow `module` to be a line by itself.

Ought to fix #138 