### PR TITLE
Bug/fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,3 @@ install:
   - echo -e "#\!/bin/bash\\n\\necho \"Running elm-make with sysconfcpus -n 2\"\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\"" > $(npm config get prefix)/bin/elm-make
   - chmod +x $(npm config get prefix)/bin/elm-make
   - npm install
-
-script:
-  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - npm --version
   - npm install -g elm@$ELM_VERSION mocha
   - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
-  - echo "#\!/bin/bash\\n\\necho \"Running elm-make with sysconfcpus -n 2\"\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\"" > $(npm config get prefix)/bin/elm-make
+  - echo -e "#\!/bin/bash\\n\\necho \"Running elm-make with sysconfcpus -n 2\"\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\"" > $(npm config get prefix)/bin/elm-make
   - chmod +x $(npm config get prefix)/bin/elm-make
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 
+language: node_js
+node_js:
+    - "node"
+    - "4"
+
 cache:
   directories:
     - test/elm-stuff/build-artifacts
@@ -9,15 +14,9 @@ os:
   - linux
   - osx
 
-env:
-  matrix:
-    - ELM_VERSION=0.18.0 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.18.0 TARGET_NODE_VERSION=4.0.0
+env: ELM_VERSION=0.18.0
 
 before_install:
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];
-    then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;
-    fi
   - | # epic build time improvement - see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
     if [ ! -d sysconfcpus/bin ];
     then
@@ -29,8 +28,6 @@ before_install:
     fi
 
 install:
-  - nvm install $TARGET_NODE_VERSION
-  - nvm use $TARGET_NODE_VERSION
   - node --version
   - npm --version
   - npm install -g elm@$ELM_VERSION mocha
@@ -38,7 +35,6 @@ install:
   - echo "#\!/bin/bash\\n\\necho \"Running elm-make with sysconfcpus -n 2\"\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\"" > $(npm config get prefix)/bin/elm-make
   - chmod +x $(npm config get prefix)/bin/elm-make
   - npm install
-
 
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "install": "node install.js",
-    "test": "node tests/ci.js && mocha tests"
+    "test": "mocha tests"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The _core_ thing is using `echo -e` when generating the sysconfcpu-ified `elm-make` - the file had literal `\n`'s in there, rather than actual newlines.

Other than that, I also switched travis to using the node-js specific containers so the whole nvm thing can be handled by travis itself, as well as using the `node_js` key to specify which node versions we should support.

Since mocha already executes `ci.js`, I removed the explicit `node ci.js` from the test-script, too.

It seems a bit odd to support `4.x` and (at the time of writing) `8.x`, though - perhaps we should consider something like 6, 7 and current to cover all bases?