### PR TITLE
`init` installs `elm-html-test` if `elm-lang/html` in dependencies

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -34,6 +34,7 @@ var compile    = require("node-elm-compiler").compile,
   chokidar     = require("chokidar"),
   Runner       = require("../lib/runner.js"),
   Init         = require("../lib/init.js");
+  child_process = require("child_process");
 
 var generatedCodeDir = path.resolve(path.join("elm-stuff", "generated-code", "elm-community", "elm-test"));
 var args = minimist(process.argv.slice(2), {
@@ -227,7 +228,10 @@ function runElmTest() {
   checkNodeVersion();
 
   if (args._[0] == "init") {
-    Init.init(args);
+    var cmdArgs = Init.init(args);
+    var cmd = ["elm-package", "install", "--yes"].concat(cmdArgs).join(" ");
+
+    child_process.execSync(cmd, { stdio: 'inherit', cwd: Init.elmPackageDir});
 
     process.exit(0);
   }

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,9 +1,13 @@
 var fs = require("fs-extra"),
   path = require("path");
 
+var elmPackageDir = "tests";
+
 function init(args) {
+  var packagesToInstall = [];
+
   if (fs.existsSync("elm-package.json")) {
-    var dest = path.resolve(path.join("tests", "elm-package.json"));
+    var dest = path.resolve(path.join(elmPackageDir, "elm-package.json"));
     ensureDirectory("tests");
 
     try {
@@ -13,6 +17,11 @@ function init(args) {
       fs.writeFileSync(dest, newElmPackageContents);
 
       logCreated(dest);
+
+      if (typeof elmPackageContents.dependencies["elm-lang/html"] === "string") {
+        // If we have elm-lang/html installed, install eeue56/elm-html-test
+        packagesToInstall = ["eeue56/elm-html-test"];
+      }
     } catch (err) {
       console.error("Error reading elm-package.json: " + err);
       process.exit(1);
@@ -32,6 +41,8 @@ function init(args) {
 
   copyTemplate(path.join("tests", "Example.elm"));
   copyTemplate("gitignore", ".gitignore");
+
+  return packagesToInstall;
 }
 
 function modifyElmPackage(elmPackageJson) {
@@ -95,5 +106,6 @@ function ensureDirectory(dirName) {
 }
 
 module.exports = {
+  elmPackageDir: elmPackageDir,
   init: init
 }


### PR DESCRIPTION
This changes `init` to save you more time installing dependencies.

If you have `elm-lang/html` in your project's dependencies, `init` now adds `elm-html-test` to your test dependencies automatically. If you don't have `elm-lang/html` in your project's dependencies, you presumably won't have a use for testing HTML, so `elm-html-test` is not added. 😄