### PR TITLE
Update the Travis Example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ install:
       make && make install;
       cd ..;
     fi
+
 before_script:
-  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make ./tests/Main.elm
+  - cd tests && $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make --yes Tests.elm && cd ..
 
 script:
-  - elm-test
+  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-test
 
 ```


### PR DESCRIPTION
Came across these differences when trying to speed up the tests for `elm-community/list-extra`:
https://github.com/elm-community/list-extra/pull/57/files

Should the `elm-stuff` folders in `tests/` be added to the cache directories as well?

Fixes the following issues:

* `tests/Main.elm` no longer exists.
* Running `elm-test` is still slow unless it is also called by `sysconfcpus`.
* The `elm-make` command fails because the top-level `elm-package.json` does not contain the test dependencies.