### PR TITLE
Sort imports in Example.elm

### DIFF
--- a/templates/tests/Example.elm
+++ b/templates/tests/Example.elm
@@ -1,8 +1,8 @@
 module Example exposing (..)
 
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, list, int, string)
 import Test exposing (..)
-import Expect
-import Fuzz exposing (list, int, string)
 
 
 suite : Test


### PR DESCRIPTION
This way if you're using `elm-format@exp` it doesn't reorder the imports in the example the first time you format it.

~~Also uses `elm-format@exp` for all the source code.~~

EDIT: Backed out the "use `elm-format@exp` everywhere" part because `npm install -g elm-format@exp` isn't working for me, so would have to disable CI verification. Will circle back to that part later.