### PR TITLE
Fix condition for reporter options

### DIFF
--- a/bin/elm-test
+++ b/bin/elm-test
@@ -318,7 +318,7 @@ function isMachineReadableReporter(reporter) {
 }
 
 function processOptsForReporter(reporter) {
-  if (isMachineReadableReporter) {
+  if (isMachineReadableReporter(reporter)) {
     return {stdio: ['ignore', 'ignore', 'pipe']};
   } else {
     return {};


### PR DESCRIPTION
While looking at the source code, I came across this line. The conditions always evaluated to true, regardless of the reporter passed to it, which I assume is not the intended behavior.