### PR TITLE
Add back line to print version for --version

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,3 +7,5 @@
 [libs]
 
 [options]
+
+module.ignore_non_literal_requires=true

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -108,6 +108,7 @@ if (args.help) {
 }
 
 if (args.version) {
+  console.log(require(path.join(__dirname, "..", "package.json")).version);
   process.exit(0);
 }
 


### PR DESCRIPTION
This line appeared to go AWOL in https://github.com/rtfeldman/node-test-runner/commit/e841c3d18085859384915a7cc7c8899752959e91, so `elm-test --version` produced no output. This adds it back in.

Thanks