### PR TITLE
Minor perf improvements, plus more accurate total test execution time

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -1,5 +1,6 @@
 // @flow
 
+var startingTime = Date.now();
 var processTitle = "elm-test";
 
 process.title = processTitle;
@@ -201,6 +202,7 @@ function runTests(testFile) {
       prepareCompiledJsFile(initialSeed, report, dest);
 
       Supervisor.run(
+        startingTime,
         dest,
         args.watch,
         isMachineReadableReporter(args.reporter)
@@ -607,6 +609,9 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
     };
 
     watcher.on("all", function(event, filePath) {
+      // Reset startingTime.
+      startingTime = Date.now();
+
       var relativePath = path.relative(elmRootDir, filePath);
       var eventName = eventNameMap[event] || event;
 

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -1,6 +1,5 @@
 // @flow
 
-var startingTime = Date.now();
 var processTitle = "elm-test";
 
 process.title = processTitle;
@@ -202,7 +201,6 @@ function runTests(testFile) {
       prepareCompiledJsFile(initialSeed, report, dest);
 
       Supervisor.run(
-        startingTime,
         dest,
         args.watch,
         isMachineReadableReporter(args.reporter)
@@ -609,9 +607,6 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
     };
 
     watcher.on("all", function(event, filePath) {
-      // Reset startingTime.
-      startingTime = Date.now();
-
       var relativePath = path.relative(elmRootDir, filePath);
       var eventName = eventNameMap[event] || event;
 

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -89,12 +89,13 @@ function run(
 
           printResult(response);
 
-          // Close all the workers.
-          workers.forEach(function(worker) {
-            worker.kill();
-          });
-
-          if (!watch) {
+          if (watch) {
+            // Close all the workers.
+            workers.forEach(function(worker) {
+              worker.kill();
+            });
+          } else {
+            // Don't bother closing workers, because we're exiting immediately.
             process.exit(response.exitCode);
           }
           break;

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -6,6 +6,7 @@ var os = require("os"),
   child_process = require("child_process");
 
 function run(
+  startingTime /*:number*/,
   dest /*:string*/,
   watch /*:boolean*/,
   isMachineReadable /*:boolean*/
@@ -19,7 +20,6 @@ function run(
   var results = [];
   var summaries = [];
   var testsToRun = -1;
-  var startingTime = Date.now();
 
   function flushResults() {
     // Only print any results if we're ready - that is, nextResultToPrint

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -6,7 +6,6 @@ var os = require("os"),
   child_process = require("child_process");
 
 function run(
-  startingTime /*:number*/,
   dest /*:string*/,
   watch /*:boolean*/,
   isMachineReadable /*:boolean*/
@@ -20,6 +19,7 @@ function run(
   var results = [];
   var summaries = [];
   var testsToRun = -1;
+  var startingTime = Date.now();
 
   function flushResults() {
     // Only print any results if we're ready - that is, nextResultToPrint

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -19,6 +19,7 @@ function run(
   var results = [];
   var summaries = [];
   var testsToRun = -1; // TODO: record this number from BEGIN
+  var startingTime = Date.now();
 
   function flushResults() {
     // Only print any results if we're ready - that is, nextResultToPrint
@@ -81,7 +82,11 @@ function run(
 
           // If all the workers have finished, print the summmary.
           if (finishedWorkers === workers.length) {
-            worker.send({ type: "SUMMARY", testResults: summaries });
+            worker.send({
+              type: "SUMMARY",
+              duration: Date.now() - startingTime,
+              testResults: summaries
+            });
           }
           break;
         case "SUMMARY":

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -39,17 +39,26 @@ function run(
     }
   }
 
-  function runNextTest(worker) {
-    var testToRun = nextTestToRun;
-
-    nextTestToRun++;
-
-    // Immediately run the next test.
-    worker.send({ type: "TEST", index: testToRun });
-  }
-
   var workers = cpus.map(function(throwaway, index) {
     var worker = child_process.fork(dest);
+    var currentlyRunningIndex = nextTestToRun;
+
+    function runNextTest() {
+      currentlyRunningIndex = nextTestToRun;
+
+      nextTestToRun++;
+
+      // Immediately run the next test.
+      if (currentlyRunningIndex === -1) {
+        // The BEGIN message requests metadata about the test run, e.g.
+        // how many tests will be run, whether they should auto-fail because
+        // of skip/on/y/todo, etc.
+        worker.send({ type: "BEGIN" });
+      } else {
+        // Send the index of the test to run.
+        worker.send({ type: "TEST", index: currentlyRunningIndex });
+      }
+    }
 
     if (watch && !isMachineReadable) {
       worker.on("close", function(code, signal) {
@@ -102,7 +111,7 @@ function run(
           nextResultToPrint = 0;
           flushResults();
 
-          runNextTest(worker);
+          runNextTest();
 
           break;
         case "TEST_COMPLETED":
@@ -115,12 +124,12 @@ function run(
           // backtrack the line feed, so that if someone else does more
           // logging, it will overwrite our status update and that's ok?
 
-          results[response.index] = response;
+          results[currentlyRunningIndex] = response;
           summaries.push(response.summary);
 
           flushResults();
 
-          runNextTest(worker);
+          runNextTest();
           break;
         case "ERROR":
           throw new Error(response.message);
@@ -129,24 +138,9 @@ function run(
       }
     });
 
+    runNextTest();
+
     return worker;
-  });
-
-  // Set the workers running.
-  workers.forEach(function(worker, index) {
-    var testToRun = nextTestToRun;
-
-    nextTestToRun++;
-
-    if (testToRun === -1) {
-      // The BEGIN message requests metadata about the test run, e.g.
-      // how many tests will be run, whether they should auto-fail because
-      // of skip/on/y/todo, etc.
-      worker.send({ type: "BEGIN" });
-    } else {
-      // Send the index of the test to run.
-      worker.send({ type: "TEST", index: testToRun });
-    }
   });
 }
 

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -18,7 +18,7 @@ function run(
   var closedWorkers = 0;
   var results = [];
   var summaries = [];
-  var testsToRun = -1; // TODO: record this number from BEGIN
+  var testsToRun = -1;
   var startingTime = Date.now();
 
   function flushResults() {

--- a/src/Test/Runner/JsMessage.elm
+++ b/src/Test/Runner/JsMessage.elm
@@ -7,7 +7,7 @@ import Test.Reporter.TestResults exposing (TestResult, unsafeTestResultDecoder)
 type JsMessage
     = Begin
     | Test Int
-    | Summary (List TestResult)
+    | Summary Float (List TestResult)
 
 
 decoder : Decoder JsMessage
@@ -27,8 +27,9 @@ decodeMessageFromType messageType =
             Decode.succeed Begin
 
         "SUMMARY" ->
-            Decode.field "testResults" (Decode.list unsafeTestResultDecoder)
-                |> Decode.map Summary
+            Decode.map2 Summary
+                (Decode.field "duration" Decode.float)
+                (Decode.field "testResults" (Decode.list unsafeTestResultDecoder))
 
         _ ->
             Decode.fail ("Unrecognized message type: " ++ messageType)

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -181,7 +181,6 @@ update msg ({ testReporter } as model) =
                 cmd =
                     Encode.object
                         [ ( "type", Encode.string "TEST_COMPLETED" )
-                        , ( "index", Encode.int testId )
                         , ( "summary", encodeRawTestResult result )
                         , ( "format", Encode.string testReporter.format )
                         , ( "message", encodedOutcome )

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -47,7 +47,6 @@ type alias TestId =
 
 type alias Model =
     { available : Dict TestId Runner
-    , startTime : Time
     , runInfo : RunInfo
     , testReporter : TestReporter
     , autoFail : Maybe String
@@ -64,7 +63,6 @@ type Msg
     = Receive Decode.Value
     | Dispatch TestId Time
     | Complete TestId (List String) (List Outcome) Time Time
-    | SendSummary (List TestResult) Time
 
 
 port send : String -> Cmd msg
@@ -106,9 +104,29 @@ update msg ({ testReporter } as model) =
                         Ok Begin ->
                             sendBegin model
 
-                        Ok (Summary results) ->
-                            Time.now
-                                |> Task.perform (SendSummary results)
+                        Ok (Summary duration completed) ->
+                            let
+                                summary =
+                                    testReporter.reportSummary duration model.autoFail completed
+
+                                defaultExitCode =
+                                    if model.autoFail == Nothing then
+                                        0
+                                    else
+                                        3
+
+                                exitCode =
+                                    List.concatMap .outcomes completed
+                                        |> getExitCode defaultExitCode
+                            in
+                            Encode.object
+                                [ ( "type", Encode.string "SUMMARY" )
+                                , ( "exitCode", Encode.int exitCode )
+                                , ( "format", Encode.string model.testReporter.format )
+                                , ( "message", summary )
+                                ]
+                                |> Encode.encode 0
+                                |> send
 
                         Ok (Test index) ->
                             if index >= model.runInfo.testCount then
@@ -131,36 +149,6 @@ update msg ({ testReporter } as model) =
 
         Dispatch index startTime ->
             ( model, dispatch model index startTime )
-
-        SendSummary completed finishTime ->
-            let
-                duration =
-                    finishTime - model.startTime
-
-                summary =
-                    testReporter.reportSummary duration model.autoFail completed
-
-                defaultExitCode =
-                    if model.autoFail == Nothing then
-                        0
-                    else
-                        3
-
-                exitCode =
-                    List.concatMap .outcomes completed
-                        |> getExitCode defaultExitCode
-
-                cmd =
-                    Encode.object
-                        [ ( "type", Encode.string "SUMMARY" )
-                        , ( "exitCode", Encode.int exitCode )
-                        , ( "format", Encode.string model.testReporter.format )
-                        , ( "message", summary )
-                        ]
-                        |> Encode.encode 0
-                        |> send
-            in
-            ( model, cmd )
 
         Complete testId labels outcomes startTime endTime ->
             let
@@ -290,7 +278,6 @@ init { startTime, paths, fuzzRuns, initialSeed, runners, report } =
 
         model =
             { available = Dict.fromList indexedRunners
-            , startTime = startTime
             , runInfo =
                 { testCount = testCount
                 , paths = paths


### PR DESCRIPTION
The supervisor is now responsible for recording how long the entire test run takes.

This means it includes the amount of time it takes to start a worker running, which seems fair.

(It still excludes what happens before the tests run, such as compilation time, as that would introduce massive variance into duration reports depending on how many compiled assets had been cached.)