### PR TITLE
Alternate parallel

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -203,7 +203,7 @@ function runTests(testFile) {
       prepareCompiledJsFile(initialSeed, report, dest);
 
       Supervisor.run(
-        report,
+        report.toUpperCase(),
         processes,
         dest,
         args.watch,

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -23,6 +23,7 @@ process.on("uncaughtException", function(error) {
 
 var compile = require("node-elm-compiler").compile,
   fs = require("fs-extra"),
+  os = require("os"),
   crypto = require("crypto"),
   glob = require("glob"),
   path = require("path"),
@@ -53,6 +54,7 @@ var args = minimist(process.argv.slice(2), {
   boolean: ["warn", "version", "help", "watch"],
   string: ["add-dependencies", "compiler", "seed", "report", "fuzz"]
 });
+var processes = os.cpus().length;
 
 // Recursively search directories for *.elm files, excluding elm-stuff/
 function resolveFilePath(filename) {
@@ -201,6 +203,7 @@ function runTests(testFile) {
       prepareCompiledJsFile(initialSeed, report, dest);
 
       Supervisor.run(
+        processes,
         dest,
         args.watch,
         isMachineReadableReporter(args.reporter)
@@ -535,6 +538,8 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
     opts.reporter +
     ", seed = " +
     opts.seed +
+    ", processes = " +
+    processes +
     ", paths = [" +
     opts.paths +
     "]}";

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -54,7 +54,7 @@ var args = minimist(process.argv.slice(2), {
   boolean: ["warn", "version", "help", "watch"],
   string: ["add-dependencies", "compiler", "seed", "report", "fuzz"]
 });
-var processes = os.cpus().length;
+var processes = Math.min(1, os.cpus().length);
 
 // Recursively search directories for *.elm files, excluding elm-stuff/
 function resolveFilePath(filename) {

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -203,6 +203,7 @@ function runTests(testFile) {
       prepareCompiledJsFile(initialSeed, report, dest);
 
       Supervisor.run(
+        report,
         processes,
         dest,
         args.watch,

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -1,12 +1,12 @@
 // @flow
 
-var os = require("os"),
-  chalk = require("chalk"),
+var chalk = require("chalk"),
   builder = require("xmlbuilder"),
   _ = require("lodash"),
   child_process = require("child_process");
 
 function run(
+  processes /*:number*/,
   dest /*:string*/,
   watch /*:boolean*/,
   isMachineReadable /*:boolean*/
@@ -39,7 +39,7 @@ function run(
     }
   }
 
-  var workers = _.range(0, os.cpus().length).map(function(index) {
+  var workers = _.range(0, processes).map(function(index) {
     var worker = child_process.fork(dest);
     var currentlyRunningIndex = nextTestToRun;
 

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -1,7 +1,7 @@
 // @flow
 
 var chalk = require("chalk"),
-  builder = require("xmlbuilder"),
+  XmlBuilder = require("xmlbuilder"),
   _ = require("lodash"),
   child_process = require("child_process");
 
@@ -12,7 +12,6 @@ function run(
   watch /*:boolean*/,
   isMachineReadable /*:boolean*/
 ) {
-  var nextTestToRun = -1;
   var nextResultToPrint = null;
   var finishedWorkers = 0;
   var closedWorkers = 0;
@@ -93,12 +92,13 @@ function run(
           printResult(response.message);
 
           if (format === "JUNIT") {
-            // TODO populate testcase - it already has the extra failure, so
-            // prepend contents of the results object to those.
-            // The results object should have a bunch of <testcase> contents
-            // at this point.
-            //  ( "testcase", Encode.list extraFailures )
-            console.log(builder.create(response.message).end());
+            var xml = response.message;
+
+            xml.testsuite.testcase = xml.testsuite.testcase.concat(
+              _.values(results)
+            );
+
+            console.log(XmlBuilder.create(xml).end());
           }
 
           if (watch) {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -68,11 +68,38 @@ function run(
       });
     }
 
+    function handleResults(response) {
+      // TODO print progress bar - e.g. "Running test 5 of 20" on a bar!
+      // -- yikes, be careful though...test the scenario where test
+      // authors put Debug.log in their tests - does that mess
+      // everything up re: the line feed? Seems like it would...
+      // ...so maybe a bar is not best. Can we do better? Hm.
+      // Maybe the answer is to print the thing, then Immediately
+      // backtrack the line feed, so that if someone else does more
+      // logging, it will overwrite our status update and that's ok?
+
+      Object.assign(results, response.results);
+
+      _.each(response.results, function(result, index) {
+        if (result === null) {
+          // It's a PASS; no need to take any action.
+        } else if (typeof result.todo !== "undefined") {
+          todos.push(result);
+        } else {
+          failures++;
+        }
+      });
+
+      flushResults();
+    }
+
     worker.on("message", function(data) {
       var response = JSON.parse(data);
 
       switch (response.type) {
         case "FINISHED":
+          handleResults(response);
+
           // This worker found no tests remaining to run; it's finished!
           finishedWorkers++;
 
@@ -97,6 +124,8 @@ function run(
             xml.testsuite.testcase = xml.testsuite.testcase.concat(
               _.values(results)
             );
+            // TODO on BEGIN, print <testsuite><testcase>, then print failures
+            // to stdout as they arrive, then print <testcase></testsuite>.
 
             console.log(XmlBuilder.create(xml).end());
           }
@@ -125,28 +154,7 @@ function run(
 
           break;
         case "RESULTS":
-          // TODO print progress bar - e.g. "Running test 5 of 20" on a bar!
-          // -- yikes, be careful though...test the scenario where test
-          // authors put Debug.log in their tests - does that mess
-          // everything up re: the line feed? Seems like it would...
-          // ...so maybe a bar is not best. Can we do better? Hm.
-          // Maybe the answer is to print the thing, then Immediately
-          // backtrack the line feed, so that if someone else does more
-          // logging, it will overwrite our status update and that's ok?
-
-          Object.assign(results, response.results);
-
-          _.each(response.results, function(index, result) {
-            if (result === null) {
-              // It's a PASS; no need to take any action.
-            } else if (typeof result.todo !== "undefined") {
-              todos.push(result);
-            } else {
-              failures++;
-            }
-          });
-
-          flushResults();
+          handleResults(response);
 
           break;
         case "ERROR":

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -3,6 +3,7 @@
 var os = require("os"),
   chalk = require("chalk"),
   builder = require("xmlbuilder"),
+  _ = require("lodash"),
   child_process = require("child_process");
 
 function run(
@@ -10,8 +11,6 @@ function run(
   watch /*:boolean*/,
   isMachineReadable /*:boolean*/
 ) {
-  var cpus = os.cpus() || new Array(1);
-
   var nextTestToRun = -1;
   var nextResultToPrint = null;
   var finishedWorkers = 0;
@@ -40,7 +39,7 @@ function run(
     }
   }
 
-  var workers = cpus.map(function(throwaway, index) {
+  var workers = _.range(0, os.cpus().length).map(function(index) {
     var worker = child_process.fork(dest);
     var currentlyRunningIndex = nextTestToRun;
 
@@ -105,8 +104,6 @@ function run(
           }
           break;
         case "BEGIN":
-          // TODO record all the relevant values, and display the "hey we're
-          // starting up here" thing to the user.
           var result = JSON.parse(data);
 
           testsToRun = result.testCount;
@@ -115,9 +112,9 @@ function run(
 
           // Now we're ready to print results!
           nextResultToPrint = 0;
-          flushResults();
 
           runNextTest();
+          flushResults();
 
           break;
         case "TEST_COMPLETED":
@@ -133,9 +130,9 @@ function run(
           results[currentlyRunningIndex] = response;
           summaries.push(response.summary);
 
+          runNextTest();
           flushResults();
 
-          runNextTest();
           break;
         case "ERROR":
           throw new Error(response.message);

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -21,6 +21,7 @@ function run(
   var todos = [];
   var testsToRun = -1;
   var startingTime = Date.now();
+  var loadBalancing = null;
 
   function printResult(result) {
     if (format === "CHALK") {
@@ -55,6 +56,16 @@ function run(
     }
   }
 
+  function beginLoadBalancing(indexToSkip) {
+    _.each(workers, function(worker, index) {
+      // The index we're skipping is the worker that requested load balancing
+      // in the first place; it already set itself to be in load balance mode.
+      if (index !== indexToSkip) {
+        worker.send({ type: "LOADBALANCE" });
+      }
+    });
+  }
+
   var workers = _.range(0, processes).map(function(index) {
     var worker = child_process.fork(dest);
 
@@ -85,6 +96,19 @@ function run(
               failures: failures,
               todos: todos
             });
+          }
+          break;
+        case "LOADBALANCE":
+          if (loadBalancing === null) {
+            // This is the first time anyone has requested load balancing.
+            loadBalancing = new Array(processes);
+
+            loadBalancing[index] = null; // This one's done.
+
+            beginLoadBalancing(index);
+          } else {
+            // This process is reporting that it's ready to be load balanced.
+            loadBalancing[index] = response.index;
           }
           break;
         case "SUMMARY":

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -17,7 +17,8 @@ function run(
   var finishedWorkers = 0;
   var closedWorkers = 0;
   var results = {};
-  var summaries = [];
+  var failures = 0;
+  var todos = [];
   var testsToRun = -1;
   var startingTime = Date.now();
 
@@ -33,7 +34,7 @@ function run(
         // Otherwise, keep going until we have no result available to print.
         typeof result !== "undefined"
       ) {
-        printResult(format, result.message);
+        printResult(format, result);
         nextResultToPrint++;
         result = results[String(nextResultToPrint)];
       }
@@ -67,7 +68,8 @@ function run(
             worker.send({
               type: "SUMMARY",
               duration: Date.now() - startingTime,
-              testResults: summaries
+              failures: failures,
+              todos: todos
             });
           }
           break;
@@ -77,6 +79,11 @@ function run(
           printResult(format, response.message);
 
           if (format === "JUNIT") {
+            // TODO populate testcase - it already has the extra failure, so
+            // prepend contents of the results object to those.
+            // The results object should have a bunch of <testcase> contents
+            // at this point.
+            //  ( "testcase", Encode.list extraFailures )
             console.log(builder.create(response.message).end());
           }
 
@@ -114,7 +121,16 @@ function run(
           // logging, it will overwrite our status update and that's ok?
 
           Object.assign(results, response.results);
-          summaries.push(response.summary);
+
+          _.values(response.results).forEach(function(result) {
+            if (result === null) {
+              // It's a PASS; no need to take any action.
+            } else if (typeof result.todo !== "undefined") {
+              todos.push(result);
+            } else {
+              failures++;
+            }
+          });
 
           flushResults();
 
@@ -132,13 +148,16 @@ function run(
   });
 }
 
-function printResult(format /*:string*/, message) {
+function printResult(format /*:string*/, result) {
   if (format === "CHALK") {
-    if (message !== null) {
-      console.log(chalkify(message));
+    // todos are objects, and will be shown in the SUMMARY only.
+    // passed tests are nulls, and should not be printed.
+    // failed tests are arrays of chalk data.
+    if (result instanceof Array) {
+      console.log(chalkify(result));
     }
   } else if (format === "JSON") {
-    console.log(JSON.stringify(message));
+    console.log(JSON.stringify(result));
   }
   // JUnit does everything at once in SUMMARY, elsewhere
 }

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -21,7 +21,6 @@ function run(
   var todos = [];
   var testsToRun = -1;
   var startingTime = Date.now();
-  var loadBalancing = null;
 
   function printResult(result) {
     if (format === "CHALK") {
@@ -56,16 +55,6 @@ function run(
     }
   }
 
-  function beginLoadBalancing(indexToSkip) {
-    _.each(workers, function(worker, index) {
-      // The index we're skipping is the worker that requested load balancing
-      // in the first place; it already set itself to be in load balance mode.
-      if (index !== indexToSkip) {
-        worker.send({ type: "LOADBALANCE" });
-      }
-    });
-  }
-
   var workers = _.range(0, processes).map(function(index) {
     var worker = child_process.fork(dest);
 
@@ -96,19 +85,6 @@ function run(
               failures: failures,
               todos: todos
             });
-          }
-          break;
-        case "LOADBALANCE":
-          if (loadBalancing === null) {
-            // This is the first time anyone has requested load balancing.
-            loadBalancing = new Array(processes);
-
-            loadBalancing[index] = null; // This one's done.
-
-            beginLoadBalancing(index);
-          } else {
-            // This process is reporting that it's ready to be load balanced.
-            loadBalancing[index] = response.index;
           }
           break;
         case "SUMMARY":

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -26,7 +26,7 @@ function run(
     // Only print any results if we're ready - that is, nextResultToPrint
     // is no longer null. (BEGIN changes it from null to 0.)
     if (nextResultToPrint !== null) {
-      var result = results[String(nextResultToPrint)];
+      var result = results[nextResultToPrint];
 
       while (
         // If there are no more results to print, then we're done.
@@ -36,7 +36,7 @@ function run(
       ) {
         printResult(format, result);
         nextResultToPrint++;
-        result = results[String(nextResultToPrint)];
+        result = results[nextResultToPrint];
       }
     }
   }

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -22,6 +22,20 @@ function run(
   var testsToRun = -1;
   var startingTime = Date.now();
 
+  function printResult(result) {
+    if (format === "CHALK") {
+      // todos are objects, and will be shown in the SUMMARY only.
+      // passed tests are nulls, and should not be printed.
+      // failed tests are arrays of chalk data.
+      if (result instanceof Array) {
+        console.log(chalkify(result));
+      }
+    } else if (format === "JSON") {
+      console.log(JSON.stringify(result));
+    }
+    // JUnit does everything at once in SUMMARY, elsewhere
+  }
+
   function flushResults() {
     // Only print any results if we're ready - that is, nextResultToPrint
     // is no longer null. (BEGIN changes it from null to 0.)
@@ -34,7 +48,7 @@ function run(
         // Otherwise, keep going until we have no result available to print.
         typeof result !== "undefined"
       ) {
-        printResult(format, result);
+        printResult(result);
         nextResultToPrint++;
         result = results[nextResultToPrint];
       }
@@ -76,7 +90,7 @@ function run(
         case "SUMMARY":
           flushResults();
 
-          printResult(format, response.message);
+          printResult(response.message);
 
           if (format === "JUNIT") {
             // TODO populate testcase - it already has the extra failure, so
@@ -102,7 +116,7 @@ function run(
 
           testsToRun = result.testCount;
 
-          printResult(format, result.message);
+          printResult(result.message);
 
           // Now we're ready to print results!
           nextResultToPrint = 0;
@@ -146,20 +160,6 @@ function run(
 
     return worker;
   });
-}
-
-function printResult(format /*:string*/, result) {
-  if (format === "CHALK") {
-    // todos are objects, and will be shown in the SUMMARY only.
-    // passed tests are nulls, and should not be printed.
-    // failed tests are arrays of chalk data.
-    if (result instanceof Array) {
-      console.log(chalkify(result));
-    }
-  } else if (format === "JSON") {
-    console.log(JSON.stringify(result));
-  }
-  // JUnit does everything at once in SUMMARY, elsewhere
 }
 
 function chalkify(messages) {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -16,7 +16,7 @@ function run(
   var nextResultToPrint = null;
   var finishedWorkers = 0;
   var closedWorkers = 0;
-  var results = [];
+  var results = {};
   var summaries = [];
   var testsToRun = -1;
   var startingTime = Date.now();
@@ -25,7 +25,7 @@ function run(
     // Only print any results if we're ready - that is, nextResultToPrint
     // is no longer null. (BEGIN changes it from null to 0.)
     if (nextResultToPrint !== null) {
-      var result = results[nextResultToPrint];
+      var result = results[String(nextResultToPrint)];
 
       while (
         // If there are no more results to print, then we're done.
@@ -33,33 +33,15 @@ function run(
         // Otherwise, keep going until we have no result available to print.
         typeof result !== "undefined"
       ) {
-        printResult(format, result);
+        printResult(format, result.message);
         nextResultToPrint++;
-        result = results[nextResultToPrint];
+        result = results[String(nextResultToPrint)];
       }
     }
   }
 
   var workers = _.range(0, processes).map(function(index) {
     var worker = child_process.fork(dest);
-    var currentlyRunningIndex = nextTestToRun;
-
-    function runNextTest() {
-      currentlyRunningIndex = nextTestToRun;
-
-      nextTestToRun++;
-
-      // Immediately run the next test.
-      if (currentlyRunningIndex === -1) {
-        // The BEGIN message requests metadata about the test run, e.g.
-        // how many tests will be run, whether they should auto-fail because
-        // of skip/on/y/todo, etc.
-        worker.send({ type: "BEGIN" });
-      } else {
-        // Send the index of the test to run.
-        worker.send({ type: "TEST", index: currentlyRunningIndex });
-      }
-    }
 
     if (watch && !isMachineReadable) {
       worker.on("close", function(code, signal) {
@@ -92,7 +74,11 @@ function run(
         case "SUMMARY":
           flushResults();
 
-          printResult(format, response);
+          printResult(format, response.message);
+
+          if (format === "JUNIT") {
+            console.log(builder.create(response.message).end());
+          }
 
           if (watch) {
             // Close all the workers.
@@ -109,16 +95,15 @@ function run(
 
           testsToRun = result.testCount;
 
-          printResult(format, result);
+          printResult(format, result.message);
 
           // Now we're ready to print results!
           nextResultToPrint = 0;
 
-          runNextTest();
           flushResults();
 
           break;
-        case "TEST_COMPLETED":
+        case "RESULTS":
           // TODO print progress bar - e.g. "Running test 5 of 20" on a bar!
           // -- yikes, be careful though...test the scenario where test
           // authors put Debug.log in their tests - does that mess
@@ -128,10 +113,9 @@ function run(
           // backtrack the line feed, so that if someone else does more
           // logging, it will overwrite our status update and that's ok?
 
-          results[currentlyRunningIndex] = response;
+          Object.assign(results, response.results);
           summaries.push(response.summary);
 
-          runNextTest();
           flushResults();
 
           break;
@@ -142,38 +126,21 @@ function run(
       }
     });
 
-    runNextTest();
+    worker.send({ type: "TEST", index: index - 1 });
 
     return worker;
   });
 }
 
-function printResult(format, data) {
-  if (data.type === "ERROR") {
-    throw new Error(data.message);
-  } else if (
-    data.type === "TEST_COMPLETED" ||
-    data.type === "SUMMARY" ||
-    data.type === "BEGIN"
-  ) {
-    if (format === "CHALK") {
-      if (data.message !== null) {
-        console.log(chalkify(data.message));
-      }
-    } else if (format === "JUNIT") {
-      if (data.type === "SUMMARY") {
-        console.log(builder.create(data.message).end());
-      }
-    } else if (format === "JSON") {
-      console.log(JSON.stringify(data.message));
-    } else {
-      console.error("Unrecognized data format:", format);
-      console.error("Full message:", data);
+function printResult(format /*:string*/, message) {
+  if (format === "CHALK") {
+    if (message !== null) {
+      console.log(chalkify(message));
     }
-  } else {
-    console.error("Unrecognized data type:", data.type);
-    console.error("Full message:", data);
+  } else if (format === "JSON") {
+    console.log(JSON.stringify(message));
   }
+  // JUnit does everything at once in SUMMARY, elsewhere
 }
 
 function chalkify(messages) {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -122,7 +122,7 @@ function run(
 
           Object.assign(results, response.results);
 
-          _.values(response.results).forEach(function(result) {
+          _.each(response.results, function(index, result) {
             if (result === null) {
               // It's a PASS; no need to take any action.
             } else if (typeof result.todo !== "undefined") {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -6,6 +6,7 @@ var chalk = require("chalk"),
   child_process = require("child_process");
 
 function run(
+  format /*:string*/,
   processes /*:number*/,
   dest /*:string*/,
   watch /*:boolean*/,
@@ -32,7 +33,7 @@ function run(
         // Otherwise, keep going until we have no result available to print.
         typeof result !== "undefined"
       ) {
-        printResult(result);
+        printResult(format, result);
         nextResultToPrint++;
         result = results[nextResultToPrint];
       }
@@ -91,7 +92,7 @@ function run(
         case "SUMMARY":
           flushResults();
 
-          printResult(response);
+          printResult(format, response);
 
           if (watch) {
             // Close all the workers.
@@ -108,7 +109,7 @@ function run(
 
           testsToRun = result.testCount;
 
-          printResult(result);
+          printResult(format, result);
 
           // Now we're ready to print results!
           nextResultToPrint = 0;
@@ -147,7 +148,7 @@ function run(
   });
 }
 
-function printResult(data) {
+function printResult(format, data) {
   if (data.type === "ERROR") {
     throw new Error(data.message);
   } else if (
@@ -155,18 +156,18 @@ function printResult(data) {
     data.type === "SUMMARY" ||
     data.type === "BEGIN"
   ) {
-    if (data.format === "CHALK") {
+    if (format === "CHALK") {
       if (data.message !== null) {
         console.log(chalkify(data.message));
       }
-    } else if (data.format === "JUNIT") {
+    } else if (format === "JUNIT") {
       if (data.type === "SUMMARY") {
         console.log(builder.create(data.message).end());
       }
-    } else if (data.format === "JSON") {
+    } else if (format === "JSON") {
       console.log(JSON.stringify(data.message));
     } else {
-      console.error("Unrecognized data format:", data.format);
+      console.error("Unrecognized data format:", format);
       console.error("Full message:", data);
     }
   } else {

--- a/native-src/Native/RunTest.js
+++ b/native-src/Native/RunTest.js
@@ -1,9 +1,5 @@
 var _rtfeldman$node_test_runner$Native_RunTest = (function() {
   return {
-    unsafeCoerce: function(a) {
-      return a;
-    },
-
     runThunk: function(thunk) {
       try {
         // Attempt to run the thunk as normal.

--- a/src/Test/Reporter/Chalk.elm
+++ b/src/Test/Reporter/Chalk.elm
@@ -99,24 +99,25 @@ reportBegin { paths, fuzzRuns, testCount, initialSeed } =
         |> Just
 
 
-reportComplete : Results.TestResult -> Value
+reportComplete : Results.TestResult -> Maybe Value
 reportComplete { duration, labels, outcome } =
     case outcome of
         Passed ->
-            -- No failures of any kind.
-            Encode.null
+            Nothing
 
         Failed failures ->
             -- We have non-TODOs still failing; report them, not the TODOs.
             failures
                 |> failuresToChalk labels
                 |> chalkWith
+                |> Just
 
         Todo str ->
-            Encode.object
-                [ ( "todo", Encode.string str )
-                , ( "labels", Encode.list (List.map Encode.string labels) )
-                ]
+            [ ( "todo", Encode.string str )
+            , ( "labels", Encode.list (List.map Encode.string labels) )
+            ]
+                |> Encode.object
+                |> Just
 
 
 summarizeTodos : List ( List String, String ) -> List Chalk

--- a/src/Test/Reporter/Chalk.elm
+++ b/src/Test/Reporter/Chalk.elm
@@ -99,25 +99,24 @@ reportBegin { paths, fuzzRuns, testCount, initialSeed } =
         |> Just
 
 
-reportComplete : Results.TestResult -> Maybe Value
+reportComplete : Results.TestResult -> Value
 reportComplete { duration, labels, outcome } =
     case outcome of
         Passed ->
-            Nothing
+            -- No failures of any kind.
+            Encode.null
 
         Failed failures ->
             -- We have non-TODOs still failing; report them, not the TODOs.
             failures
                 |> failuresToChalk labels
                 |> chalkWith
-                |> Just
 
         Todo str ->
-            [ ( "todo", Encode.string str )
-            , ( "labels", Encode.list (List.map Encode.string labels) )
-            ]
-                |> Encode.object
-                |> Just
+            Encode.object
+                [ ( "todo", Encode.string str )
+                , ( "labels", Encode.list (List.map Encode.string labels) )
+                ]
 
 
 summarizeTodos : List ( List String, String ) -> List Chalk

--- a/src/Test/Reporter/JUnit.elm
+++ b/src/Test/Reporter/JUnit.elm
@@ -57,24 +57,29 @@ encodeTime time =
         |> Encode.string
 
 
-reportComplete : TestResult -> Value
-reportComplete { labels, duration, outcome } =
+reportComplete : TestResult -> Maybe Value
+reportComplete =
+    encodeTestResult >> Just
+
+
+encodeTestResult : TestResult -> Value
+encodeTestResult { labels, duration, outcome } =
     let
         ( classname, name ) =
             formatClassAndName labels
     in
-    Encode.object
-        ([ ( "@classname", Encode.string classname )
-         , ( "@name", Encode.string name )
-         , ( "@time", encodeTime duration )
-         ]
-            ++ encodeOutcome outcome
-        )
+    ([ ( "@classname", Encode.string classname )
+     , ( "@name", Encode.string name )
+     , ( "@time", encodeTime duration )
+     ]
+        ++ encodeOutcome outcome
+    )
+        |> Encode.object
 
 
 encodeExtraFailure : String -> Value
 encodeExtraFailure failure =
-    reportComplete { labels = [], duration = 0, outcome = Failed [] }
+    encodeTestResult { labels = [], duration = 0, outcome = Failed [] }
 
 
 reportSummary : SummaryInfo -> Maybe String -> Value

--- a/src/Test/Reporter/JUnit.elm
+++ b/src/Test/Reporter/JUnit.elm
@@ -57,29 +57,24 @@ encodeTime time =
         |> Encode.string
 
 
-reportComplete : TestResult -> Maybe Value
-reportComplete =
-    encodeTestResult >> Just
-
-
-encodeTestResult : TestResult -> Value
-encodeTestResult { labels, duration, outcome } =
+reportComplete : TestResult -> Value
+reportComplete { labels, duration, outcome } =
     let
         ( classname, name ) =
             formatClassAndName labels
     in
-    ([ ( "@classname", Encode.string classname )
-     , ( "@name", Encode.string name )
-     , ( "@time", encodeTime duration )
-     ]
-        ++ encodeOutcome outcome
-    )
-        |> Encode.object
+    Encode.object
+        ([ ( "@classname", Encode.string classname )
+         , ( "@name", Encode.string name )
+         , ( "@time", encodeTime duration )
+         ]
+            ++ encodeOutcome outcome
+        )
 
 
 encodeExtraFailure : String -> Value
 encodeExtraFailure failure =
-    encodeTestResult { labels = [], duration = 0, outcome = Failed [] }
+    reportComplete { labels = [], duration = 0, outcome = Failed [] }
 
 
 reportSummary : SummaryInfo -> Maybe String -> Value

--- a/src/Test/Reporter/Json.elm
+++ b/src/Test/Reporter/Json.elm
@@ -16,16 +16,15 @@ reportBegin { paths, fuzzRuns, testCount, initialSeed } =
         |> Just
 
 
-reportComplete : TestResults.TestResult -> Maybe Value
+reportComplete : TestResults.TestResult -> Value
 reportComplete { duration, labels, outcome } =
-    [ ( "event", Encode.string "testCompleted" )
-    , ( "status", Encode.string (getStatus outcome) )
-    , ( "labels", encodeLabels labels )
-    , ( "failures", Encode.list (encodeFailures outcome) )
-    , ( "duration", Encode.string <| toString duration )
-    ]
-        |> Encode.object
-        |> Just
+    Encode.object
+        [ ( "event", Encode.string "testCompleted" )
+        , ( "status", Encode.string (getStatus outcome) )
+        , ( "labels", encodeLabels labels )
+        , ( "failures", Encode.list (encodeFailures outcome) )
+        , ( "duration", Encode.string <| toString duration )
+        ]
 
 
 encodeFailures : Outcome -> List Value

--- a/src/Test/Reporter/Json.elm
+++ b/src/Test/Reporter/Json.elm
@@ -16,15 +16,16 @@ reportBegin { paths, fuzzRuns, testCount, initialSeed } =
         |> Just
 
 
-reportComplete : TestResults.TestResult -> Value
+reportComplete : TestResults.TestResult -> Maybe Value
 reportComplete { duration, labels, outcome } =
-    Encode.object
-        [ ( "event", Encode.string "testCompleted" )
-        , ( "status", Encode.string (getStatus outcome) )
-        , ( "labels", encodeLabels labels )
-        , ( "failures", Encode.list (encodeFailures outcome) )
-        , ( "duration", Encode.string <| toString duration )
-        ]
+    [ ( "event", Encode.string "testCompleted" )
+    , ( "status", Encode.string (getStatus outcome) )
+    , ( "labels", encodeLabels labels )
+    , ( "failures", Encode.list (encodeFailures outcome) )
+    , ( "duration", Encode.string <| toString duration )
+    ]
+        |> Encode.object
+        |> Just
 
 
 encodeFailures : Outcome -> List Value

--- a/src/Test/Reporter/Reporter.elm
+++ b/src/Test/Reporter/Reporter.elm
@@ -32,7 +32,7 @@ fromString str =
 type alias TestReporter =
     { format : String
     , reportBegin : RunInfo -> Maybe Value
-    , reportComplete : TestResult -> Value
+    , reportComplete : TestResult -> Maybe Value
     , reportSummary : SummaryInfo -> Maybe String -> Value
     }
 

--- a/src/Test/Reporter/Reporter.elm
+++ b/src/Test/Reporter/Reporter.elm
@@ -32,7 +32,7 @@ fromString str =
 type alias TestReporter =
     { format : String
     , reportBegin : RunInfo -> Maybe Value
-    , reportComplete : TestResult -> Maybe Value
+    , reportComplete : TestResult -> Value
     , reportSummary : SummaryInfo -> Maybe String -> Value
     }
 

--- a/src/Test/Reporter/Reporter.elm
+++ b/src/Test/Reporter/Reporter.elm
@@ -4,8 +4,7 @@ import Json.Encode as Encode exposing (Value)
 import Test.Reporter.Chalk as ChalkReporter
 import Test.Reporter.JUnit as JUnitReporter
 import Test.Reporter.Json as JsonReporter
-import Test.Reporter.TestResults exposing (TestResult)
-import Time exposing (Time)
+import Test.Reporter.TestResults exposing (SummaryInfo, TestResult)
 
 
 type Report
@@ -33,8 +32,8 @@ fromString str =
 type alias TestReporter =
     { format : String
     , reportBegin : RunInfo -> Maybe Value
-    , reportComplete : TestResult -> Maybe Value
-    , reportSummary : Time -> Maybe String -> List TestResult -> Value
+    , reportComplete : TestResult -> Value
+    , reportSummary : SummaryInfo -> Maybe String -> Value
     }
 
 

--- a/src/Test/Runner/JsMessage.elm
+++ b/src/Test/Runner/JsMessage.elm
@@ -5,6 +5,7 @@ import Json.Decode as Decode exposing (Decoder)
 
 type JsMessage
     = Test Int
+    | LoadBalance
     | Summary Float Int (List ( List String, String ))
 
 
@@ -20,6 +21,9 @@ decodeMessageFromType messageType =
         "TEST" ->
             Decode.field "index" Decode.int
                 |> Decode.map Test
+
+        "LOADBALANCE" ->
+            Decode.succeed LoadBalance
 
         "SUMMARY" ->
             Decode.map3 Summary

--- a/src/Test/Runner/JsMessage.elm
+++ b/src/Test/Runner/JsMessage.elm
@@ -5,8 +5,7 @@ import Test.Reporter.TestResults exposing (TestResult, unsafeTestResultDecoder)
 
 
 type JsMessage
-    = Begin
-    | Test Int
+    = Test Int
     | Summary Float (List TestResult)
 
 
@@ -22,9 +21,6 @@ decodeMessageFromType messageType =
         "TEST" ->
             Decode.field "index" Decode.int
                 |> Decode.map Test
-
-        "BEGIN" ->
-            Decode.succeed Begin
 
         "SUMMARY" ->
             Decode.map2 Summary

--- a/src/Test/Runner/JsMessage.elm
+++ b/src/Test/Runner/JsMessage.elm
@@ -5,7 +5,6 @@ import Json.Decode as Decode exposing (Decoder)
 
 type JsMessage
     = Test Int
-    | LoadBalance
     | Summary Float Int (List ( List String, String ))
 
 
@@ -21,9 +20,6 @@ decodeMessageFromType messageType =
         "TEST" ->
             Decode.field "index" Decode.int
                 |> Decode.map Test
-
-        "LOADBALANCE" ->
-            Decode.succeed LoadBalance
 
         "SUMMARY" ->
             Decode.map3 Summary

--- a/src/Test/Runner/JsMessage.elm
+++ b/src/Test/Runner/JsMessage.elm
@@ -1,12 +1,11 @@
 module Test.Runner.JsMessage exposing (JsMessage(..), decoder)
 
 import Json.Decode as Decode exposing (Decoder)
-import Test.Reporter.TestResults exposing (TestResult, unsafeTestResultDecoder)
 
 
 type JsMessage
     = Test Int
-    | Summary Float (List TestResult)
+    | Summary Float Int (List ( List String, String ))
 
 
 decoder : Decoder JsMessage
@@ -23,9 +22,17 @@ decodeMessageFromType messageType =
                 |> Decode.map Test
 
         "SUMMARY" ->
-            Decode.map2 Summary
+            Decode.map3 Summary
                 (Decode.field "duration" Decode.float)
-                (Decode.field "testResults" (Decode.list unsafeTestResultDecoder))
+                (Decode.field "failures" Decode.int)
+                (Decode.field "todos" (Decode.list todoDecoder))
 
         _ ->
             Decode.fail ("Unrecognized message type: " ++ messageType)
+
+
+todoDecoder : Decoder ( List String, String )
+todoDecoder =
+    Decode.map2 (,)
+        (Decode.field "labels" (Decode.list Decode.string))
+        (Decode.field "todo" Decode.string)

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -49,6 +49,9 @@ type alias Model =
     { available : Dict TestId Runner
     , runInfo : RunInfo
     , testReporter : TestReporter
+    , summaries : List Outcome
+    , processes : Int
+    , nextTestToRun : Maybe TestId
     , autoFail : Maybe String
     }
 
@@ -237,16 +240,8 @@ sendBegin model =
         |> send
 
 
-init :
-    { initialSeed : Int
-    , paths : List String
-    , fuzzRuns : Int
-    , startTime : Time
-    , runners : SeededRunners
-    , report : Report
-    }
-    -> ( Model, Cmd Msg )
-init { startTime, paths, fuzzRuns, initialSeed, runners, report } =
+init : App.InitArgs -> ( Model, Cmd Msg )
+init { startTime, processes, paths, fuzzRuns, initialSeed, runners, report } =
     let
         { indexedRunners, autoFail } =
             case runners of
@@ -284,6 +279,9 @@ init { startTime, paths, fuzzRuns, initialSeed, runners, report } =
                 , fuzzRuns = fuzzRuns
                 , initialSeed = initialSeed
                 }
+            , processes = processes
+            , nextTestToRun = Nothing
+            , summaries = []
             , testReporter = testReporter
             , autoFail = autoFail
             }

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -53,7 +53,6 @@ type alias Model =
     , processes : Int
     , nextTestToRun : TestId
     , autoFail : Maybe String
-    , loadBalanced : Bool
     }
 
 
@@ -146,16 +145,8 @@ update msg ({ testReporter } as model) =
                         ( { model | nextTestToRun = index + model.processes }
                         , Cmd.batch [ cmd, sendBegin model ]
                         )
-                    else if index >= model.runInfo.testCount then
-                        -- If the index is out of bounds, we're all finished!
-                        ( model, sendResults True testReporter model.results )
                     else
                         ( { model | nextTestToRun = index }, cmd )
-
-                Ok LoadBalance ->
-                    ( { model | loadBalanced = True }
-                    , sendLoadBalanceInfo model.nextTestToRun
-                    )
 
                 Err err ->
                     let
@@ -190,68 +181,28 @@ update msg ({ testReporter } as model) =
                     model.nextTestToRun + model.processes
 
                 isFinished =
-                    -- If we're load balanced, the load balancer will tell us
-                    -- when we're finished by sending us a Test index that's
-                    -- out of bounds.
-                    not model.loadBalanced
-                        && (nextTestToRun >= model.runInfo.testCount)
-
-                needsLoadBalancing =
-                    -- If this is our last run before we will be finished,
-                    -- we're gonna need load balancing!
-                    not model.loadBalanced
-                        && (nextTestToRun + model.processes >= model.runInfo.testCount)
-
-                shouldBeLoadBalanced =
-                    model.loadBalanced || needsLoadBalancing
+                    nextTestToRun >= model.runInfo.testCount
             in
             if isFinished || List.any isFailure outcomes then
                 let
-                    newModel =
-                        { model
-                            | nextTestToRun = nextTestToRun
-                            , results = []
-                            , loadBalanced = shouldBeLoadBalanced
-                        }
-
                     cmd =
                         sendResults isFinished testReporter results
                 in
                 if isFinished then
-                    ( newModel, cmd )
+                    -- Don't bother updating the model, since we're done
+                    ( model, cmd )
                 else
                     -- Clear out the results, now that we've flushed them.
-                    ( newModel
-                    , if model.loadBalanced then
-                        cmd
-                      else if needsLoadBalancing then
-                        Cmd.batch
-                            [ cmd
-                            , sendLoadBalanceInfo nextTestToRun
-                            , Task.perform Dispatch Time.now
-                            ]
-                      else
-                        Cmd.batch
-                            [ cmd
-                            , Task.perform Dispatch Time.now
-                            ]
+                    ( { model | nextTestToRun = nextTestToRun, results = [] }
+                    , Cmd.batch
+                        [ cmd
+                        , Task.perform Dispatch Time.now
+                        ]
                     )
             else
-                let
-                    newModel =
-                        { model
-                            | nextTestToRun = nextTestToRun
-                            , results = results
-                            , loadBalanced = shouldBeLoadBalanced
-                        }
-
-                    cmd =
-                        Task.perform Dispatch Time.now
-                in
-                if needsLoadBalancing then
-                    ( newModel, Cmd.batch [ cmd, sendLoadBalanceInfo nextTestToRun ] )
-                else
-                    ( newModel, cmd )
+                ( { model | nextTestToRun = nextTestToRun, results = results }
+                , Task.perform Dispatch Time.now
+                )
 
 
 countFailures : ( TestId, TestResult ) -> Int -> Int
@@ -327,16 +278,6 @@ sendBegin model =
         |> send
 
 
-sendLoadBalanceInfo : Int -> Cmd msg
-sendLoadBalanceInfo index =
-    [ ( "type", Encode.string "LOADBALANCE" )
-    , ( "index", Encode.int index )
-    ]
-        |> Encode.object
-        |> Encode.encode 0
-        |> send
-
-
 init : App.InitArgs -> ( Model, Cmd Msg )
 init { startTime, processes, paths, fuzzRuns, initialSeed, runners, report } =
     let
@@ -381,7 +322,6 @@ init { startTime, processes, paths, fuzzRuns, initialSeed, runners, report } =
             , results = []
             , testReporter = testReporter
             , autoFail = autoFail
-            , loadBalanced = False
             }
     in
     ( model, Cmd.none )

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -228,13 +228,40 @@ sendResults isFinished testReporter results =
         [ ( "type", Encode.string typeStr )
         , ( "results"
           , results
-                |> List.reverse
-                |> List.map (\( testId, result ) -> ( toString testId, testReporter.reportComplete result ))
+                |> encodeResultsHelp testReporter []
                 |> Encode.object
           )
         ]
         |> Encode.encode 0
         |> send
+
+
+{-| Results have been accumulated in reverse order. This reverses them again,
+while converting them to the desired format.
+-}
+encodeResultsHelp :
+    TestReporter
+    -> List ( String, Value )
+    -> List ( TestId, TestResult )
+    -> List ( String, Value )
+encodeResultsHelp testReporter output pairs =
+    case pairs of
+        [] ->
+            output
+
+        ( testId, result ) :: rest ->
+            case testReporter.reportComplete result of
+                Nothing ->
+                    -- Leave out Nothing values on purpose. The Chalk runner
+                    -- uses this as a performance optimization, avoiding sending
+                    -- a lot of Pass results between processes.
+                    encodeResultsHelp testReporter output rest
+
+                Just val ->
+                    encodeResultsHelp
+                        testReporter
+                        (( toString testId, val ) :: output)
+                        rest
 
 
 encodeExpectation : Expectation -> Value

--- a/src/Test/Runner/Node.elm
+++ b/src/Test/Runner/Node.elm
@@ -120,7 +120,7 @@ update msg ({ testReporter } as model) =
                         exitCode =
                             if failed > 0 then
                                 2
-                            else if model.autoFail == Nothing then
+                            else if model.autoFail == Nothing && List.isEmpty todos then
                                 0
                             else
                                 3

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -1,10 +1,10 @@
-require('shelljs/global');
-var _ = require('lodash');
-var fs = require('fs-extra');
-var path = require('path');
-var spawn = require('cross-spawn');
+require("shelljs/global");
+var _ = require("lodash");
+var fs = require("fs-extra");
+var path = require("path");
+var spawn = require("cross-spawn");
 
-var filename = __filename.replace(__dirname + '/', '');
+var filename = __filename.replace(__dirname + "/", "");
 var elmTest = "elm-test";
 
 function run(testFile) {
@@ -15,14 +15,36 @@ function run(testFile) {
     var cmd = [elmTest, testFile].join(" ");
 
     echo("Running: " + cmd);
-    return exec(cmd).code
+    return exec(cmd).code;
+  }
+}
+
+function assertTestIncomplete(testfile) {
+  var code = run(testfile);
+  if (code !== 3) {
+    exec(
+      "echo " +
+        filename +
+        ": error: " +
+        (testfile ? testfile + ": " : "") +
+        "expected tests to exit with INCOMPLETE exit code, not exit code" +
+        code +
+        " >&2"
+    );
+    exit(1);
   }
 }
 
 function assertTestFailure(testfile) {
   var code = run(testfile);
   if (code < 2) {
-    exec('echo ' + filename + ': error: ' + (testfile ? testfile + ': ' : '') + 'expected tests to fail >&2');
+    exec(
+      "echo " +
+        filename +
+        ": error: " +
+        (testfile ? testfile + ": " : "") +
+        "expected tests to fail >&2"
+    );
     exit(1);
   }
 }
@@ -30,38 +52,54 @@ function assertTestFailure(testfile) {
 function assertTestSuccess(testFile) {
   var code = run(testFile);
   if (code !== 0) {
-    exec('echo ' + filename + ': ERROR: ' + (testFile ? testFile + ': ' : '') + 'Expected tests to pass >&2');
+    exec(
+      "echo " +
+        filename +
+        ": ERROR: " +
+        (testFile ? testFile + ": " : "") +
+        "Expected tests to pass >&2"
+    );
     exit(1);
   }
 }
 
-echo(filename + ': Uninstalling old elm-test...');
-exec('npm remove --ignore-scripts=false --global ' + elmTest);
+echo(filename + ": Uninstalling old elm-test...");
+exec("npm remove --ignore-scripts=false --global " + elmTest);
 
-echo(filename + ': Installing elm-test...');
-exec('npm link --ignore-scripts=false');
+echo(filename + ": Installing elm-test...");
+exec("npm link --ignore-scripts=false");
 
 var binaryExtension = process.platform === "win32" ? ".exe" : "";
-var interfacePath = path.resolve(path.join(__dirname, "..", "bin", "elm-interface-to-json" + binaryExtension));
+var interfacePath = path.resolve(
+  path.join(__dirname, "..", "bin", "elm-interface-to-json" + binaryExtension)
+);
 if (!fs.existsSync(interfacePath)) {
-  echo(filename + ': Failed because elm-interface-to-json was not found at ' + interfacePath);
+  echo(
+    filename +
+      ": Failed because elm-interface-to-json was not found at " +
+      interfacePath
+  );
   exit(1);
 }
 
-echo(filename + ': Verifying installed elm-interface-to-json...');
+echo(filename + ": Verifying installed elm-interface-to-json...");
 var interfaceExitCode = spawn.sync(interfacePath, ["--help"]).status;
 
 if (interfaceExitCode !== 0) {
-  echo(filename + ': Failed because `elm-interface-to-json` is present, but `elm-interface-to-json --help` returned with exit code ' + interfaceExitCode);
+  echo(
+    filename +
+      ": Failed because `elm-interface-to-json` is present, but `elm-interface-to-json --help` returned with exit code " +
+      interfaceExitCode
+  );
   exit(1);
 }
 
-echo(filename + ': Verifying installed elm-test version...');
-exec(elmTest + ' --version');
+echo(filename + ": Verifying installed elm-test version...");
+exec(elmTest + " --version");
 
-echo('### Testing elm-test on example/');
+echo("### Testing elm-test on example/");
 
-cd('example');
+cd("example");
 
 assertTestSuccess(path.join("tests", "*Pass*"));
 assertTestFailure(path.join("tests", "*Fail*"));
@@ -75,36 +113,40 @@ ls("tests/*.elm").forEach(function(testToRun) {
     echo("\n### Testing " + testToRun + " (expecting it to fail)\n");
     assertTestFailure(testToRun);
   } else {
-    echo("Tried to run " + testToRun + " but it has an invalid filename; node-test-runner tests should fit the pattern \"*Passing.elm\" or \"*Failing.elm\"");
+    echo(
+      "Tried to run " +
+        testToRun +
+        ' but it has an invalid filename; node-test-runner tests should fit the pattern "*Passing.elm" or "*Failing.elm"'
+    );
     process.exit(1);
   }
 });
 
-cd('..');
+cd("..");
 
-echo('### Testing elm-test init && elm-test');
-rm('-Rf', 'tmp');
-mkdir('-p', 'tmp');
-cd('tmp');
-exec(elmTest + ' init --yes');
-assertTestFailure();
+echo("### Testing elm-test init && elm-test");
+rm("-Rf", "tmp");
+mkdir("-p", "tmp");
+cd("tmp");
+exec(elmTest + " init --yes");
+assertTestIncomplete();
 
-cd('..');
+cd("..");
 
-echo('\n### Testing elm-test init on a non-empty directory\n');
-rm('-Rf', 'tmp');
-cp('-R', 'tests/init-test', 'tmp');
-cd('tmp');
-exec(elmTest + ' init --yes');
-assertTestFailure();
+echo("\n### Testing elm-test init on a non-empty directory\n");
+rm("-Rf", "tmp");
+cp("-R", "tests/init-test", "tmp");
+cd("tmp");
+exec(elmTest + " init --yes");
+assertTestIncomplete();
 
-cd('..');
-rm('-Rf', 'tmp');
+cd("..");
+rm("-Rf", "tmp");
 
-echo('');
-echo(filename + ': Everything looks good!');
-echo('                                                            ');
-echo('  __   ,_   _  __,  -/-     ,         __   __   _   ,    ,  ');
-echo('_(_/__/ (__(/_(_/(__/_    _/_)__(_/__(_,__(_,__(/__/_)__/_)_');
-echo(' _/_                                                        ');
-echo('(/                                                          ');
+echo("");
+echo(filename + ": Everything looks good!");
+echo("                                                            ");
+echo("  __   ,_   _  __,  -/-     ,         __   __   _   ,    ,  ");
+echo("_(_/__/ (__(/_(_/(__/_    _/_)__(_/__(_,__(_,__(/__/_)__/_)_");
+echo(" _/_                                                        ");
+echo("(/                                                          ");


### PR DESCRIPTION
Predistribute instead of load balancing.

Fixes a perf problem when all tests were passing; IPC overhead is costly!

(Also makes perf worse when 1+ tests are failing; will address that later.)