### PR TITLE
Use fs.link/symlin instead of copying files

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -351,9 +351,18 @@ function runElmTest() {
   // to avoid re-downloading and recompiling things we already
   // just downloaded and compiled.
   var newElmStuffPath = path.join(newElmPackageDir, "elm-stuff");
+  var testElmStuffPath = path.join(testRootDir, "elm-stuff");
+
+  // Use original elm-stuff as a starting point for tests; it's bound to help
+  // in practice!
+  if (!fs.existsSync(path.join(testElmStuffPath, "build-artifacts"))) {
+    fs.copySync(path.join(originalDir, "elm-stuff"), testElmStuffPath, {
+      preserveTimestamps: true
+    });
+  }
 
   if (!fs.existsSync(newElmStuffPath)) {
-    fs.linkSync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
+    fs.linkSync(testElmStuffPath, newElmStuffPath);
   }
 
   ensurePackagesInstalled(newElmPackageDir);

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -353,11 +353,11 @@ function runElmTest() {
   var newElmStuffPath = path.join(newElmPackageDir, "elm-stuff");
 
   if (!fs.existsSync(newElmStuffPath)) {
-    if (process.platform === "win32") {
-      fs.linkSync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
-    } else {
-      fs.symlinkSync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
-    }
+    fs.symlinkSync(
+      path.join(testRootDir, "elm-stuff"),
+      newElmStuffPath,
+      "junction" // Only affects Windows, but necessary for this to work there. See https://github.com/gulpjs/vinyl-fs/issues/210
+    );
   }
 
   ensurePackagesInstalled(newElmPackageDir);

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -351,18 +351,9 @@ function runElmTest() {
   // to avoid re-downloading and recompiling things we already
   // just downloaded and compiled.
   var newElmStuffPath = path.join(newElmPackageDir, "elm-stuff");
-  var testElmStuffPath = path.join(testRootDir, "elm-stuff");
-
-  // Use original elm-stuff as a starting point for tests; it's bound to help
-  // in practice!
-  if (!fs.existsSync(path.join(testElmStuffPath, "build-artifacts"))) {
-    fs.copySync(path.join(originalDir, "elm-stuff"), testElmStuffPath, {
-      preserveTimestamps: true
-    });
-  }
 
   if (!fs.existsSync(newElmStuffPath)) {
-    fs.linkSync(testElmStuffPath, newElmStuffPath);
+    fs.linkSync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
   }
 
   ensurePackagesInstalled(newElmPackageDir);

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -345,22 +345,24 @@ function runElmTest() {
   var generatedSrc = returnValues[1];
   var sourceDirs = returnValues[2];
 
-  ensurePackagesInstalled(testRootDir, newElmPackageDir);
+  ensurePackagesInstalled(testRootDir);
+
+  // Hard link our existing elm-stuff into the generated code,
+  // to avoid re-downloading and recompiling things we already
+  // just downloaded and compiled.
+  var newElmStuffPath = path.join(newElmPackageDir, "elm-stuff");
+
+  if (!fs.existsSync(newElmStuffPath)) {
+    fs.linkSync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
+  }
+
+  ensurePackagesInstalled(newElmPackageDir);
 
   compileAllTests(testFilePaths)
     .then(function() {
       return Runner.findTests(testRootDir, testFilePaths, sourceDirs)
         .then(function(runnableTests) {
           process.chdir(newElmPackageDir);
-
-          // Copy our elm-stuff into the generated code, to avoid re-downloading
-          // and re-building things we already just downloaded and built.
-          var newElmStuffPath = path.join(newElmPackageDir, "elm-stuff");
-
-          if (!fs.existsSync(newElmStuffPath)) {
-            fs.mkdirpSync(newElmStuffPath);
-            fs.copySync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
-          }
 
           generateAndRunTests(
             runnableTests,
@@ -485,14 +487,12 @@ function generatePackageJson(filePathArgs) {
   return [newElmPackageDir, generatedSrc, sourceDirs];
 }
 
-function ensurePackagesInstalled(originalDir, newElmPackageDir) {
+function ensurePackagesInstalled(dir) {
   // We need to install missing packages here.
   var cmd = [pathToElmPackage, "install", "--yes"].join(" ");
   var processOpts = processOptsForReporter(report);
 
-  [originalDir, newElmPackageDir].map(function(dir) {
-    child_process.execSync(cmd, Object.assign({}, processOpts, { cwd: dir }));
-  });
+  child_process.execSync(cmd, Object.assign({}, processOpts, { cwd: dir }));
 }
 
 function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -353,7 +353,11 @@ function runElmTest() {
   var newElmStuffPath = path.join(newElmPackageDir, "elm-stuff");
 
   if (!fs.existsSync(newElmStuffPath)) {
-    fs.linkSync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
+    if (process.platform === "win32") {
+      fs.linkSync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
+    } else {
+      fs.symlinkSync(path.join(testRootDir, "elm-stuff"), newElmStuffPath);
+    }
   }
 
   ensurePackagesInstalled(newElmPackageDir);


### PR DESCRIPTION
based on #185, but platform specific.

This works in our codebase.