### PR TITLE
Fix --watch error reporting

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -66,8 +66,11 @@ function run(
     var worker = child_process.fork(dest);
 
     worker.on("close", function(code, signal) {
+      // code can be null.
+      var hasNonZeroExitCode = typeof code === "number" && code !== 0;
+
       if (watch && !isMachineReadable) {
-        if (code !== 0) {
+        if (hasNonZeroExitCode) {
           reportRuntimeException();
         }
         closedWorkers++;
@@ -75,7 +78,7 @@ function run(
         if (closedWorkers === workers.length) {
           console.log(chalk.blue("Watching for changes..."));
         }
-      } else if (code !== 0) {
+      } else if (hasNonZeroExitCode) {
         reportRuntimeException();
         process.exit(1);
       }

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -62,6 +62,8 @@ function run(
     );
   }
 
+  var pendingException = false;
+
   var workers = _.range(0, processes).map(function(index) {
     var worker = child_process.fork(dest);
 
@@ -71,11 +73,19 @@ function run(
 
       if (watch && !isMachineReadable) {
         if (hasNonZeroExitCode) {
-          reportRuntimeException();
+          // Queue up complaining about an exception.
+          // Don't print it immediately, or else it might print N times
+          // where N is the number of cores.
+          pendingException = true;
         }
         closedWorkers++;
         // If all the workers have closed, we're done! Continue watching.
         if (closedWorkers === workers.length) {
+          if (pendingException) {
+            // If we had an exception pending, print it and clear pending flag.
+            reportRuntimeException();
+            pendingException = false;
+          }
           console.log(chalk.blue("Watching for changes..."));
         }
       } else if (hasNonZeroExitCode) {


### PR DESCRIPTION
On current `master`, `--watch` (incorrectly) reports a runtime exception error when *any* test fails, not just when a runtime exception occurred.

Also makes it so we don't print the runtime exception message 4 times on a 4-core machine.