### PR TITLE
silence installer when we run json/junit reporter

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,7 +1,7 @@
 var path = require("path");
 var install = require(path.join(__dirname, "installer"));
 
-install().then(
+install(true).then(
   function(successMessage) {
     console.log(successMessage);
   },

--- a/installer.js
+++ b/installer.js
@@ -1,4 +1,4 @@
-module.exports = function() {
+module.exports = function(verbose) {
   var binstall = require("binstall");
   var path = require("path");
   var fs = require("fs");
@@ -14,8 +14,10 @@ module.exports = function() {
   var operatingSystem = process.platform;
 
   var filename = operatingSystem + "-" + arch + ".tar.gz";
-  var url =
-    "https://dl.bintray.com/elmlang/elm-test/" + binVersion + "/" + filename;
+  var url = "https://dl.bintray.com/elmlang/elm-test/" +
+    binVersion +
+    "/" +
+    filename;
 
   var binariesDir = path.join(__dirname, "bin");
   var packageInfo = require(path.join(__dirname, "package.json"));
@@ -23,14 +25,17 @@ module.exports = function() {
   var executablePaths = [
     path.join(binariesDir, "elm-interface-to-json" + binaryExtension)
   ];
-  var errorMessage =
-    "Unfortunately, there are no elm-test " +
+  var errorMessage = "Unfortunately, there are no elm-test " +
     binVersion +
     " binaries available on your operating system and architecture.\n\nIf you would like to build Elm from source, there are instructions at https://github.com/elm-lang/elm-platform#build-from-source\n";
 
   return binstall(
     url,
     { path: binariesDir },
-    { verbose: true, verify: executablePaths, errorMessage: errorMessage }
+    {
+      verbose: verbose,
+      verify: executablePaths,
+      errorMessage: errorMessage
+    }
   );
 };

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -314,12 +314,11 @@ function runElmTest() {
   var testFilePaths = _.flatMap(globs, resolveFilePath);
 
   if (testFilePaths.length === 0) {
-    var errorMessage =
-      filePathArgs.length > 0
-        ? 'No tests found for the file pattern "' +
+    var errorMessage = filePathArgs.length > 0
+      ? 'No tests found for the file pattern "' +
           filePathArgs.toString() +
           '"\n\nMaybe try running elm-test with no arguments?'
-        : "No tests found in the test/ (or tests/) directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm-package.json lives.\n\nTo generate some initial tests to get things going, run elm-test init";
+      : "No tests found in the test/ (or tests/) directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm-package.json lives.\n\nTo generate some initial tests to get things going, run elm-test init";
 
     console.error(errorMessage);
     process.exit(1);
@@ -364,7 +363,12 @@ function runElmTest() {
 
   compileAllTests(testFilePaths)
     .then(function() {
-      return Runner.findTests(testRootDir, testFilePaths, sourceDirs)
+      return Runner.findTests(
+        testRootDir,
+        testFilePaths,
+        sourceDirs,
+        !isMachineReadableReporter(report)
+      )
         .then(function(runnableTests) {
           process.chdir(newElmPackageDir);
 
@@ -509,24 +513,21 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
     return "import " + test.name;
   });
   var testList = _.map(tests, function(mod) {
-    return (
-      '    Test.describe "' +
+    return '    Test.describe "' +
       mod.name +
       '" [' +
       _.map(mod.tests, function(test) {
         return mod.name + "." + test;
       }).join(",\n    ") +
-      "]"
-    );
+      "]";
   });
 
   if (testList.length === 0) {
-    var errorMessage =
-      filePathArgs.length > 0
-        ? "I couldn't find any exposed values of type Test in files matching \"" +
+    var errorMessage = filePathArgs.length > 0
+      ? "I couldn't find any exposed values of type Test in files matching \"" +
           filePathArgs.toString() +
           '"\n\nMaybe try running elm-test with no arguments?'
-        : "I couldn't find any exposed values of type Test in any *.elm files in the test/ (or tests/) directory of your project's root directory.\n\nTo generate some initial tests to get things going, run elm-test init";
+      : "I couldn't find any exposed values of type Test in any *.elm files in the test/ (or tests/) directory of your project's root directory.\n\nTo generate some initial tests to get things going, run elm-test init";
 
     console.error(errorMessage);
     process.exit(1);
@@ -560,8 +561,7 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
     paths: filePathArgs.map(sanitizedToString).join(",")
   };
 
-  var optsCode =
-    "{ runs = " +
+  var optsCode = "{ runs = " +
     opts.fuzz +
     ", report = " +
     opts.report +
@@ -629,9 +629,10 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
     }
 
     var watchedSourcePaths = fs
-      .readJsonSync(path.join(originalDir, "elm-package.json"), "utf8")[
-        "source-directories"
-      ]
+      .readJsonSync(
+        path.join(originalDir, "elm-package.json"),
+        "utf8"
+      )["source-directories"]
       .map(resolveWatchPath(originalDir));
     var watchedTestPaths = fs
       .readJsonSync(elmPackagePath, "utf8")["source-directories"]
@@ -668,9 +669,7 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
 var report;
 
 if (
-  args.report === "console" ||
-  args.report === "json" ||
-  args.report === "junit"
+  args.report === "console" || args.report === "json" || args.report === "junit"
 ) {
   report = args.report;
 } else if (args.report !== undefined) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -25,8 +25,7 @@ function copyNativeSrcFiles(
 
       copyNativeSrcFiles(newPackageName, filePath, newDest);
     } else if (
-      (stats.isFile() || stats.isSymbolicLink()) &&
-      isJsFile(filename)
+      (stats.isFile() || stats.isSymbolicLink()) && isJsFile(filename)
     ) {
       var contents = fs.readFileSync(filePath, "utf8");
 
@@ -89,8 +88,8 @@ function findNearestElmPackageDir(filePaths /*:Array<string>*/) {
 }
 
 var binaryExtension = process.platform === "win32" ? ".exe" : "";
-var readElmiPath =
-  path.join(__dirname, "..", "bin", "elm-interface-to-json") + binaryExtension;
+var readElmiPath = path.join(__dirname, "..", "bin", "elm-interface-to-json") +
+  binaryExtension;
 
 function moduleFromFilePath(filePathArg) {
   var parsed = path.parse(path.normalize(filePathArg));
@@ -153,7 +152,8 @@ function toPathsAndModules(
 function findTests(
   elmPackageJsonPath /*: string*/,
   testFilePaths /*: Array<string>*/,
-  sourceDirs /*: Array<string>*/
+  sourceDirs /*: Array<string>*/,
+  verbose /*: boolean*/
 ) {
   return new Promise(function(resolve, reject) {
     function finish() {
@@ -225,7 +225,7 @@ function findTests(
     } else {
       // it wasn't downloaded, possibly because we were installed with
       // --ignore-scripts - so download it!
-      return installReadElmi().then(finish).catch(reject);
+      return installReadElmi(verbose).then(finish).catch(reject);
     }
   });
 }
@@ -272,12 +272,11 @@ function filterExposing(pathAndModule) {
     return finder
       .readExposing(pathAndModule.path)
       .then(function(exposedValues) {
-        var newTests =
-          exposedValues.length === 1 && exposedValues[0] === ".."
-            ? // null exposedValues means "the module was exposing (..), so keep everything"
-              pathAndModule.tests
-            : // Only keep the tests that were exposed.
-              _.intersection(exposedValues, pathAndModule.tests);
+        var newTests = exposedValues.length === 1 && exposedValues[0] === ".."
+          ? // null exposedValues means "the module was exposing (..), so keep everything"
+            pathAndModule.tests
+          : // Only keep the tests that were exposed.
+            _.intersection(exposedValues, pathAndModule.tests);
 
         if (newTests.length < pathAndModule.tests.length) {
           return reject(


### PR DESCRIPTION
If you pipe the output from `report junit` into a file then the xml is sometimes not valid. The reason for this is that `binstall` runs with `verbose: true`. So `
Downloading binaries from https://dl.bintray.com/elmlang/elm-test/0.18.8/linux-x64.tar.gz`
is in the produced xml. This PR attempts to run binstall only in verbose mode when elm-test runs in a none-machinereadable way.
this was caught by @ento ❤️ 