### PR TITLE
Chokidar file watcher: Await write finish

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -639,6 +639,9 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
     var watchedPaths = watchedSourcePaths.concat(watchedTestPaths);
 
     var watcher = chokidar.watch(watchedPaths, {
+      awaitWriteFinish: {
+        stabilityThreshold: 500
+      },
       ignoreInitial: true,
       ignored: /(\/|^)elm-stuff(\/|$)/
     });


### PR DESCRIPTION
Change [chokidar](https://github.com/paulmillr/chokidar) settings to await file change. This fixes the problem that `elm-format` configured on save, will trigger `elm-test` in watch mode twice. It will lead to `500 ms` latency in watch mode, but it seems to be acceptable in comparison to running twice.

Fixes #194 