### PR TITLE
Appveyor settings to use latest node version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   ELM_VERSION: "0.18.0"
   matrix:
-  - nodejs_version: "5.0"
-  - nodejs_version: "4.0"
+  - nodejs_version: "8"
+  - nodejs_version: "4"
 
 platform:
   - x86

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -160,7 +160,6 @@ describe("flags", () => {
 
   describe("--compiler", () => {
     it("Should fail if the given compiler can't be executed", () => {
-
       const runResult = shell.exec(
         "elm-test --compiler=foobar tests/OnePassing.elm",
         { silent: true }
@@ -181,15 +180,19 @@ describe("flags", () => {
       let hasRetriggered = false;
 
       child.stdout.on("data", line => {
-        const parsedLine = JSON.parse(line);
-        if (parsedLine.event === "runComplete" && !hasRetriggered) {
-          shell.touch("tests/OnePassing.elm");
-          hasRetriggered = true;
-        }
+        try {
+          const parsedLine = JSON.parse(line);
+          if (parsedLine.event === "runComplete" && !hasRetriggered) {
+            shell.touch("tests/OnePassing.elm");
+            hasRetriggered = true;
+          }
 
-        if (parsedLine.event == "runComplete" && hasRetriggered) {
-          child.kill();
-          done();
+          if (parsedLine.event == "runComplete" && hasRetriggered) {
+            child.kill();
+            done();
+          }
+        } catch (e) {
+          console.warn("Unexpected non-json output: " + line);
         }
       });
     }).timeout(60000);


### PR DESCRIPTION
Appveyor was using initial release `v4.0.0` which has issues. Trevor settings will use the latest minor version `v4.8.4`. Settings are consistent now. I compared the configuration to other projects and this is how they are configured to reach the wanted behavior.

More information and screenshots in [this comment](https://github.com/rtfeldman/node-test-runner/pull/197#issuecomment-320312023)