### PR TITLE
add --skip-install flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ source-directories), your tests will get rerun.
 elm-test --watch
 ```
 
+#### `--skip-install`
+
+Skips the missing packages check.  Useful for when offline.  Just make sure all of the necessary packages have previously been installed.
+
+```
+elm-test --skip-install
+```
+
 #### `--help`
 
 Displays all the available options and commands.

--- a/README.md
+++ b/README.md
@@ -88,14 +88,6 @@ source-directories), your tests will get rerun.
 elm-test --watch
 ```
 
-#### `--skip-install`
-
-Skips the missing packages check.  Useful for when offline.  Just make sure all of the necessary packages have previously been installed.
-
-```
-elm-test --skip-install
-```
-
 #### `--help`
 
 Displays all the available options and commands.

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -116,8 +116,7 @@ if (args.help) {
     "[--add-dependencies path-to-destination-elm-package.json] # Add missing dependencies from current elm-package.json to destination",
     "[--report json, junit, or console (default)] # Print results to stdout in given format",
     "[--version] # Print version string and exit",
-    "[--watch] # Run tests on file changes",
-    "[--skip-install] # Skip missing packages check (useful when no internet connection)"
+    "[--watch] # Run tests on file changes"
   ].forEach(printUsage);
 
   process.exit(1);
@@ -497,11 +496,6 @@ function generatePackageJson(filePathArgs) {
 }
 
 function ensurePackagesInstalled(dir) {
-  if (args["skip-install"]) {
-    infoLog("Warning: Skipping missing packages check.");
-    return true;
-  }
-
   // We need to install missing packages here.
   var cmd = [pathToElmPackage, "install", "--yes"].join(" ");
   var processOpts = processOptsForReporter(report);

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -500,7 +500,11 @@ function ensurePackagesInstalled(dir) {
   var cmd = [pathToElmPackage, "install", "--yes"].join(" ");
   var processOpts = processOptsForReporter(report);
 
-  child_process.execSync(cmd, Object.assign({}, processOpts, { cwd: dir }));
+  try {
+    child_process.execSync(cmd, Object.assign({}, processOpts, { cwd: dir }));
+  } catch(e) {
+    infoLog("Warning: Unable to complete missing packages check.");
+  }
 }
 
 function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -116,7 +116,8 @@ if (args.help) {
     "[--add-dependencies path-to-destination-elm-package.json] # Add missing dependencies from current elm-package.json to destination",
     "[--report json, junit, or console (default)] # Print results to stdout in given format",
     "[--version] # Print version string and exit",
-    "[--watch] # Run tests on file changes"
+    "[--watch] # Run tests on file changes",
+    "[--skip-install] # Skip missing packages check (useful when no internet connection)"
   ].forEach(printUsage);
 
   process.exit(1);

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -496,6 +496,11 @@ function generatePackageJson(filePathArgs) {
 }
 
 function ensurePackagesInstalled(dir) {
+  if (args["skip-install"]) {
+    infoLog("Warning: Skipping missing packages check.");
+    return true;
+  }
+
   // We need to install missing packages here.
   var cmd = [pathToElmPackage, "install", "--yes"].join(" ");
   var processOpts = processOptsForReporter(report);


### PR DESCRIPTION
I often code on the bus or places without internet.  Because of the missing packages check, I can't run my tests in these situations.

This change makes it possible to opt out of the package check so I can run my tests again without wifi.