### PR TITLE
Adds a "processes" flag to specify parallelism explicitly

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -51,12 +51,15 @@ var args = minimist(process.argv.slice(2), {
     compiler: "c",
     "add-dependencies": "a",
     report: "r",
-    watch: "w"
+    watch: "w",
+    processes: "p"
   },
   boolean: ["warn", "version", "help", "watch"],
-  string: ["add-dependencies", "compiler", "seed", "report", "fuzz"]
+  string: ["add-dependencies", "compiler", "seed", "report", "fuzz", "processes"]
 });
-var processes = Math.max(1, os.cpus().length);
+
+var maxProcesses = parseInt(args.processes) || os.cpus().length;
+var processes = Math.max(1, maxProcesses);
 
 // Recursively search directories for *.elm files, excluding elm-stuff/
 function resolveFilePath(filename) {
@@ -116,7 +119,8 @@ if (args.help) {
     "[--add-dependencies path-to-destination-elm-package.json] # Add missing dependencies from current elm-package.json to destination",
     "[--report json, junit, or console (default)] # Print results to stdout in given format",
     "[--version] # Print version string and exit",
-    "[--watch] # Run tests on file changes"
+    "[--watch] # Run tests on file changes",
+    "[--processes integer] # Number of processes to use running tests (defaults to the number of CPUs)"
   ].forEach(printUsage);
 
   process.exit(1);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "find-parent-dir": "^0.3.0",
     "firstline": "1.2.1",
     "fs-extra": "0.30.0",
-    "fsevents": "1.1.2",
     "glob": "^7.1.1",
     "lodash": "4.13.1",
     "minimist": "^1.2.0",
@@ -45,6 +44,9 @@
     "node-elm-compiler": "4.3.2",
     "supports-color": "4.2.0",
     "xmlbuilder": "^8.2.2"
+  },
+  "optionalDependencies": {
+    "fsevents": "1.1.2"
   },
   "devDependencies": {
     "flow-bin": "0.48.0",


### PR DESCRIPTION
@rtfeldman This change works for me as a solution to #201, but:
1. You may not want to add a flag.
2. Since `elm-test` invokes `elm-make` and the two programs use different mechanisms to choose how many jobs to use, I still need to use both `sysconfcpus` and this new `--processes` flag when running `elm-test`, which is clearly gross. I don't have a solution in mind for this.

Oh, the `fsevents` change: without this, my install fails when I'm building a Docker image for CircleCI:
```
error fsevents@1.1.2: The platform "linux" is incompatible with this module.
error Found incompatible module
```
