### PR TITLE
UNIX sockets/Windows pipes

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -1,6 +1,7 @@
 // @flow
 
 var packageInfo = require("../package.json");
+var pipeFilename = require("./pipe-filename.js");
 var processTitle = "elm-test";
 
 process.title = processTitle;
@@ -239,6 +240,7 @@ function prepareCompiledJsFile(initialSeed, report, dest) {
     "})({});",
     "var initialSeed = " + String(initialSeed) + ";",
     'var report = "' + report + '";',
+    "var pipeFilename = " + JSON.stringify(pipeFilename) + ";",
     after
   ].join("\n");
 
@@ -503,7 +505,7 @@ function ensurePackagesInstalled(dir) {
 
   try {
     child_process.execSync(cmd, Object.assign({}, processOpts, { cwd: dir }));
-  } catch(e) {
+  } catch (e) {
     infoLog("Warning: Unable to complete missing packages check.");
   }
 }

--- a/lib/pipe-filename.js
+++ b/lib/pipe-filename.js
@@ -1,0 +1,3 @@
+//@flow
+module.exports =
+  process.platform === "win32" ? "\\\\.\\pipe\\elm_test" : "/tmp/elm_test.sock";

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -6,10 +6,7 @@ var chalk = require("chalk"), // Chalk is used only for the "Watching for change
   fs = require("fs-extra"),
   net = require("net"),
   child_process = require("child_process"),
-  pipeFilename =
-    process.platform === "win32"
-      ? "\\\\.\\pipe\\elm_test"
-      : "/tmp/elm_test.sock";
+  pipeFilename = require("./pipe-filename.js");
 
 function run(
   elmTestVersion /*:string*/,

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -3,6 +3,8 @@
 var chalk = require("chalk"), // Chalk is used only for the "Watching for changes..." message
   XmlBuilder = require("xmlbuilder"),
   _ = require("lodash"),
+  fs = require("fs-extra"),
+  net = require("net"),
   child_process = require("child_process");
 
 function run(
@@ -20,7 +22,9 @@ function run(
   var failures = 0;
   var todos = [];
   var testsToRun = -1;
+  var initializedWorkers = -1;
   var startingTime = Date.now();
+  var workers = [];
 
   function printResult(result) {
     if (format === "console") {
@@ -62,162 +66,184 @@ function run(
     );
   }
 
-  var pendingException = false;
+  function handleResults(response) {
+    // TODO print progress bar - e.g. "Running test 5 of 20" on a bar!
+    // -- yikes, be careful though...test the scenario where test
+    // authors put Debug.log in their tests - does that mess
+    // everything up re: the line feed? Seems like it would...
+    // ...so maybe a bar is not best. Can we do better? Hm.
+    // Maybe the answer is to print the thing, then Immediately
+    // backtrack the line feed, so that if someone else does more
+    // logging, it will overwrite our status update and that's ok?
 
-  var workers = _.range(0, processes).map(function(index) {
-    var worker = child_process.fork(dest);
+    _.each(response.results, function(result, index) {
+      results.set(parseInt(index), result);
 
-    worker.on("close", function(code, signal) {
-      // code can be null.
-      var hasNonZeroExitCode = typeof code === "number" && code !== 0;
-
-      if (watch && !isMachineReadable) {
-        if (hasNonZeroExitCode) {
-          // Queue up complaining about an exception.
-          // Don't print it immediately, or else it might print N times
-          // where N is the number of cores.
-          pendingException = true;
-        }
-        closedWorkers++;
-        // If all the workers have closed, we're done! Continue watching.
-        if (closedWorkers === workers.length) {
-          if (pendingException) {
-            // If we had an exception pending, print it and clear pending flag.
-            reportRuntimeException();
-            pendingException = false;
+      switch (format) {
+        case "console":
+          if (result === null) {
+            // It's a PASS; no need to take any action.
+          } else if (typeof result.todo !== "undefined") {
+            todos.push(result);
+          } else {
+            failures++;
           }
-          console.log(chalk.blue("Watching for changes..."));
-        }
-      } else if (hasNonZeroExitCode) {
-        reportRuntimeException();
-        process.exit(1);
+          break;
+        case "junit":
+          if (typeof result.failure !== "undefined") {
+            failures++;
+          }
+          break;
+        case "json":
+          if (result.status === "fail") {
+            failures++;
+          } else if (result.status === "todo") {
+            todos.push({ labels: result.labels, todo: result.failures[0] });
+          }
+          break;
       }
     });
 
-    function handleResults(response) {
-      // TODO print progress bar - e.g. "Running test 5 of 20" on a bar!
-      // -- yikes, be careful though...test the scenario where test
-      // authors put Debug.log in their tests - does that mess
-      // everything up re: the line feed? Seems like it would...
-      // ...so maybe a bar is not best. Can we do better? Hm.
-      // Maybe the answer is to print the thing, then Immediately
-      // backtrack the line feed, so that if someone else does more
-      // logging, it will overwrite our status update and that's ok?
+    flushResults();
+  }
 
-      _.each(response.results, function(result, index) {
-        results.set(parseInt(index), result);
+  function initWorker(socket) {
+    socket.setEncoding("utf8");
+    socket.setNoDelay(true);
 
-        switch (format) {
-          case "console":
-            if (result === null) {
-              // It's a PASS; no need to take any action.
-            } else if (typeof result.todo !== "undefined") {
-              todos.push(result);
+    socket.on("data", function(data) {
+      // See the long note near client.write() in worker.js for why we do this.
+      // It fixes a nasty bug!
+      var withoutTrailingComma = data.substring(0, data.length - 1),
+        json = "[" + withoutTrailingComma + "]",
+        responses = JSON.parse(json);
+
+      responses.forEach(function(response) {
+        switch (response.type) {
+          case "FINISHED":
+            handleResults(response);
+
+            // This worker found no tests remaining to run; it's finished!
+            finishedWorkers++;
+
+            // If all the workers have finished, print the summmary.
+            if (finishedWorkers === workers.length) {
+              socket.write(
+                JSON.stringify({
+                  type: "SUMMARY",
+                  duration: Date.now() - startingTime,
+                  failures: failures,
+                  todos: todos
+                })
+              );
+            }
+            break;
+          case "SUMMARY":
+            flushResults();
+
+            printResult(response.message);
+
+            if (format === "junit") {
+              var xml = response.message;
+              var values = Array.from(results);
+
+              xml.testsuite.testcase = xml.testsuite.testcase.concat(values);
+
+              console.log(XmlBuilder.create(xml).end());
+            }
+
+            if (watch) {
+              // Close all the workers.
+              workers.forEach(function(worker) {
+                worker.kill();
+              });
             } else {
-              failures++;
+              // Don't bother closing workers, because we're exiting immediately.
+              process.exit(response.exitCode);
             }
             break;
-          case "junit":
-            if (typeof result.failure !== "undefined") {
-              failures++;
+          case "BEGIN":
+            testsToRun = response.testCount;
+
+            if (!isMachineReadable) {
+              var headline = "elm-test " + elmTestVersion;
+              var bar = _.repeat("-", headline.length);
+
+              console.log("\n" + headline + "\n" + bar + "\n");
             }
+
+            printResult(response.message);
+
+            // Now we're ready to print results!
+            nextResultToPrint = 0;
+
+            flushResults();
+
             break;
-          case "json":
-            if (result.status === "fail") {
-              failures++;
-            } else if (result.status === "todo") {
-              todos.push({ labels: result.labels, todo: result.failures[0] });
+          case "RESULTS":
+            handleResults(response);
+
+            break;
+          case "ERROR":
+            throw new Error(response.message);
+          default:
+            throw new Error(
+              "Unrecognized message from worker:" + response.type
+            );
+        }
+      });
+    });
+
+    socket.write(JSON.stringify({ type: "TEST", index: initializedWorkers }));
+
+    initializedWorkers++;
+  }
+
+  var pendingException = false,
+    server = net.createServer(initWorker);
+
+  server.on("error", function(err) {
+    console.error(err.stack);
+    server.close();
+  });
+
+  server.on("listening", function() {
+    workers = _.range(0, processes).map(function(index) {
+      var worker = child_process.fork(dest);
+
+      worker.on("close", function(code, signal) {
+        // code can be null.
+        var hasNonZeroExitCode = typeof code === "number" && code !== 0;
+
+        if (watch && !isMachineReadable) {
+          if (hasNonZeroExitCode) {
+            // Queue up complaining about an exception.
+            // Don't print it immediately, or else it might print N times
+            // where N is the number of cores.
+            pendingException = true;
+          }
+          closedWorkers++;
+          // If all the workers have closed, we're done! Continue watching.
+          if (closedWorkers === workers.length) {
+            if (pendingException) {
+              // If we had an exception pending, print it and clear pending flag.
+              reportRuntimeException();
+              pendingException = false;
             }
-            break;
+            console.log(chalk.blue("Watching for changes..."));
+          }
+        } else if (hasNonZeroExitCode) {
+          reportRuntimeException();
+          process.exit(1);
         }
       });
 
-      flushResults();
-    }
-
-    worker.on("message", function(data) {
-      var response = JSON.parse(data);
-
-      switch (response.type) {
-        case "FINISHED":
-          handleResults(response);
-
-          // This worker found no tests remaining to run; it's finished!
-          finishedWorkers++;
-
-          // If all the workers have finished, print the summmary.
-          if (finishedWorkers === workers.length) {
-            worker.send({
-              type: "SUMMARY",
-              duration: Date.now() - startingTime,
-              failures: failures,
-              todos: todos
-            });
-          }
-          break;
-        case "SUMMARY":
-          flushResults();
-
-          printResult(response.message);
-
-          if (format === "junit") {
-            var xml = response.message;
-            var values = Array.from(results);
-
-            xml.testsuite.testcase = xml.testsuite.testcase.concat(values);
-
-            console.log(XmlBuilder.create(xml).end());
-          }
-
-          if (watch) {
-            // Close all the workers.
-            workers.forEach(function(worker) {
-              worker.kill();
-            });
-          } else {
-            // Don't bother closing workers, because we're exiting immediately.
-            process.exit(response.exitCode);
-          }
-          break;
-        case "BEGIN":
-          var result = JSON.parse(data);
-
-          testsToRun = result.testCount;
-
-          if (!isMachineReadable) {
-            var headline = "elm-test " + elmTestVersion;
-            var bar = _.repeat("-", headline.length);
-
-            console.log("\n" + headline + "\n" + bar + "\n");
-          }
-
-          printResult(result.message);
-
-          // Now we're ready to print results!
-          nextResultToPrint = 0;
-
-          flushResults();
-
-          break;
-        case "RESULTS":
-          handleResults(response);
-
-          break;
-        case "ERROR":
-          throw new Error(response.message);
-        default:
-          throw new Error("Unrecognized message from worker:" + response.type);
-      }
+      return worker;
     });
-
-    return worker;
   });
 
-  // To avoid race conditions, don't have the workers start executing tests
-  // until all processes are up and running.
-  workers.forEach(function(worker, index) {
-    worker.send({ type: "TEST", index: index - 1 });
-  });
+  fs.removeSync("/tmp/elm_test.sock");
+  server.listen("/tmp/elm_test.sock");
 }
 
 function makeWindowsSafe(text) {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -5,7 +5,11 @@ var chalk = require("chalk"), // Chalk is used only for the "Watching for change
   _ = require("lodash"),
   fs = require("fs-extra"),
   net = require("net"),
-  child_process = require("child_process");
+  child_process = require("child_process"),
+  pipeFilename =
+    process.platform === "win32"
+      ? "\\\\.\\pipe\\elm_test"
+      : "/tmp/elm_test.sock";
 
 function run(
   elmTestVersion /*:string*/,
@@ -242,8 +246,8 @@ function run(
     });
   });
 
-  fs.removeSync("/tmp/elm_test.sock");
-  server.listen("/tmp/elm_test.sock");
+  fs.removeSync(pipeFilename);
+  server.listen(pipeFilename);
 }
 
 function makeWindowsSafe(text) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.18.9-beta1",
+  "version": "0.18.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/templates/after.js
+++ b/templates/after.js
@@ -15,10 +15,6 @@ if (potentialModuleNames.length !== 1) {
 }
 
 var net = require("net"),
-  pipeFilename =
-    process.platform === "win32"
-      ? "\\\\.\\pipe\\elm_test"
-      : "/tmp/elm_test.sock",
   client = net.createConnection(pipeFilename);
 
 client.on("error", function(error) {

--- a/templates/after.js
+++ b/templates/after.js
@@ -14,16 +14,35 @@ if (potentialModuleNames.length !== 1) {
   process.exit(1);
 }
 
+var net = require("net"),
+  client = net.createConnection("/tmp/elm_test.sock");
+
+client.on("error", function(error) {
+  console.error(error);
+  client.end();
+  process.exit(1);
+});
+
+client.setEncoding("utf8");
+client.setNoDelay(true);
+
 var testModule = Elm.Test.Generated[potentialModuleNames[0]];
 
 // Run the Elm app.
 var app = testModule.worker({ seed: initialSeed, report: report });
 
-// Use ports for inter-process communication.
-app.ports.send.subscribe(function(msg) {
-  process.send(msg);
+client.on("data", function(msg) {
+  app.ports.receive.send(JSON.parse(msg));
 });
 
-process.on("message", function(msg) {
-  app.ports.receive.send(msg);
+// Use ports for inter-process communication.
+app.ports.send.subscribe(function(msg) {
+  // We do this in order to prevent a bug where two back-to-back-json
+  // messages get passed, resulting in the supervisor trying to parse
+  // "{ ...json object 1... }{ ...json object 2... }" which won't parse.
+  // By appending a comma, and having the supervisor strip the
+  // trailing comma and wrap the whole thing in [], the above becomes
+  // the valid JSON string "[{ ...json object 1... },{ ...json object 2... }]"
+  // and all is well!
+  client.write(msg + ",");
 });

--- a/templates/after.js
+++ b/templates/after.js
@@ -15,7 +15,11 @@ if (potentialModuleNames.length !== 1) {
 }
 
 var net = require("net"),
-  client = net.createConnection("/tmp/elm_test.sock");
+  pipeFilename =
+    process.platform === "win32"
+      ? "\\\\.\\pipe\\elm_test"
+      : "/tmp/elm_test.sock",
+  client = net.createConnection(pipeFilename);
 
 client.on("error", function(error) {
   console.error(error);


### PR DESCRIPTION
(This looks like a really big diff, but most if it is just code that got moved around.)

This changes the inter-process communication method from `process.send` to using UNIX sockets and Windows pipes. The startup time is about the same, but the per-message cost is 3-4ms for `process.send` and sub-millisecond for sockets.

As it stands, this is a negligible performance improvement. However, it unlocks being able to do a proper round-robin of assigning tests to processes, such that we can minimize starvation toward the end of the run. (The current algorithm optimizes for the fewest IPC messages, but we shouldn't need to do that anymore after this is merged.)

There is a small (but nonzero) chance that the weirdness in https://github.com/rtfeldman/node-test-runner/issues/201 has something to do with `process.send` and that this randomly fixes it, but I'm not holding my breath. 😛 