### PR TITLE
Change default repository path to avoid elm-test #210

### DIFF
--- a/templates/tests/elm-package.json
+++ b/templates/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "4.0.0",
     "summary": "Test Suites",
-    "repository": "https://github.com/elm-community/elm-test.git",
+    "repository": "https://github.com/user/project.git",
     "license": "BSD-3-Clause",
     "source-directories": [
         "."


### PR DESCRIPTION
The previous default is causing namespace collisions with the project we're testing, so we need this path to be different than the path that elm-test itself is using. 
https://github.com/elm-community/elm-test/issues/210