### PR TITLE
Split on newlines rather than reading as an array

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -157,7 +157,7 @@ function findTests(
   testFilePaths /*: Array<string>*/,
   sourceDirs /*: Array<string>*/,
   verbose /*: boolean*/
-) {
+)/*:Promise<void>*/ {
   return new Promise(function(resolve, reject) {
     function finish() {
       var process = spawn(readElmiPath, ["--path", elmPackageJsonPath]);

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -6,7 +6,8 @@ var chalk = require("chalk"), // Chalk is used only for the "Watching for change
   fs = require("fs-extra"),
   net = require("net"),
   child_process = require("child_process"),
-  pipeFilename = require("./pipe-filename.js");
+  pipeFilename = require("./pipe-filename.js"),
+  split = require("split");
 
 function run(
   elmTestVersion /*:string*/,
@@ -112,87 +113,83 @@ function run(
     socket.setEncoding("utf8");
     socket.setNoDelay(true);
 
-    socket.on("data", function(data) {
-      // See the long note near client.write() in worker.js for why we do this.
-      // It fixes a nasty bug!
-      var withoutTrailingComma = data.substring(0, data.length - 1),
-        json = "[" + withoutTrailingComma + "]",
-        responses = JSON.parse(json);
+    // See the long note near client.write() in worker.js for why we do this.
+    // It fixes a nasty bug!
+    var stream = socket.pipe(split());
 
-      responses.forEach(function(response) {
-        switch (response.type) {
-          case "FINISHED":
-            handleResults(response);
+    stream.on("data", function(data) {
+      var response = JSON.parse(data);
 
-            // This worker found no tests remaining to run; it's finished!
-            finishedWorkers++;
+      switch (response.type) {
+        case "FINISHED":
+          handleResults(response);
 
-            // If all the workers have finished, print the summmary.
-            if (finishedWorkers === workers.length) {
-              socket.write(
-                JSON.stringify({
-                  type: "SUMMARY",
-                  duration: Date.now() - startingTime,
-                  failures: failures,
-                  todos: todos
-                })
-              );
-            }
-            break;
-          case "SUMMARY":
-            flushResults();
+          // This worker found no tests remaining to run; it's finished!
+          finishedWorkers++;
 
-            printResult(response.message);
-
-            if (format === "junit") {
-              var xml = response.message;
-              var values = Array.from(results);
-
-              xml.testsuite.testcase = xml.testsuite.testcase.concat(values);
-
-              console.log(XmlBuilder.create(xml).end());
-            }
-
-            if (watch) {
-              // Close all the workers.
-              workers.forEach(function(worker) {
-                worker.kill();
-              });
-            } else {
-              // Don't bother closing workers, because we're exiting immediately.
-              process.exit(response.exitCode);
-            }
-            break;
-          case "BEGIN":
-            testsToRun = response.testCount;
-
-            if (!isMachineReadable) {
-              var headline = "elm-test " + elmTestVersion;
-              var bar = _.repeat("-", headline.length);
-
-              console.log("\n" + headline + "\n" + bar + "\n");
-            }
-
-            printResult(response.message);
-
-            // Now we're ready to print results!
-            nextResultToPrint = 0;
-
-            flushResults();
-
-            break;
-          case "RESULTS":
-            handleResults(response);
-
-            break;
-          case "ERROR":
-            throw new Error(response.message);
-          default:
-            throw new Error(
-              "Unrecognized message from worker:" + response.type
+          // If all the workers have finished, print the summmary.
+          if (finishedWorkers === workers.length) {
+            socket.write(
+              JSON.stringify({
+                type: "SUMMARY",
+                duration: Date.now() - startingTime,
+                failures: failures,
+                todos: todos
+              })
             );
-        }
-      });
+          }
+          break;
+        case "SUMMARY":
+          flushResults();
+
+          printResult(response.message);
+
+          if (format === "junit") {
+            var xml = response.message;
+            var values = Array.from(results);
+
+            xml.testsuite.testcase = xml.testsuite.testcase.concat(values);
+
+            console.log(XmlBuilder.create(xml).end());
+          }
+
+          if (watch) {
+            // Close all the workers.
+            workers.forEach(function(worker) {
+              worker.kill();
+            });
+          } else {
+            // Don't bother closing workers, because we're exiting immediately.
+            process.exit(response.exitCode);
+          }
+          break;
+        case "BEGIN":
+          testsToRun = response.testCount;
+
+          if (!isMachineReadable) {
+            var headline = "elm-test " + elmTestVersion;
+            var bar = _.repeat("-", headline.length);
+
+            console.log("\n" + headline + "\n" + bar + "\n");
+          }
+
+          printResult(response.message);
+
+          // Now we're ready to print results!
+          nextResultToPrint = 0;
+
+          flushResults();
+
+          break;
+        case "RESULTS":
+          handleResults(response);
+
+          break;
+        case "ERROR":
+          throw new Error(response.message);
+        default:
+          throw new Error("Unrecognized message from worker:" + response.type);
+      }
     });
 
     socket.write(JSON.stringify({ type: "TEST", index: initializedWorkers }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2175,6 +2175,14 @@
         "hoek": "2.16.3"
       }
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
@@ -2251,6 +2259,11 @@
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tough-cookie": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "minimist": "^1.2.0",
     "murmur-hash-js": "1.0.0",
     "node-elm-compiler": "4.3.3",
+    "split": "^1.0.1",
     "supports-color": "4.2.0",
     "xmlbuilder": "^8.2.2"
   },

--- a/templates/after.js
+++ b/templates/after.js
@@ -37,12 +37,11 @@ client.on("data", function(msg) {
 
 // Use ports for inter-process communication.
 app.ports.send.subscribe(function(msg) {
-  // We do this in order to prevent a bug where two back-to-back-json
-  // messages get passed, resulting in the supervisor trying to parse
-  // "{ ...json object 1... }{ ...json object 2... }" which won't parse.
-  // By appending a comma, and having the supervisor strip the
-  // trailing comma and wrap the whole thing in [], the above becomes
-  // the valid JSON string "[{ ...json object 1... },{ ...json object 2... }]"
-  // and all is well!
-  client.write(msg + ",");
+  // We split incoming messages on the socket on newlines. The gist is that node
+  // is rather unpredictable in whether or not a single `write` will result in a
+  // single `on('data')` callback. Sometimes it does, sometimes multiple writes
+  // result in a single callback and - worst of all - sometimes a single read
+  // results in multiple callbacks, each receiving a piece of the data. The
+  // horror.
+  client.write(msg + "\n");
 });

--- a/tests/SeveralWithCommentsFailing.elm
+++ b/tests/SeveralWithCommentsFailing.elm
@@ -1,4 +1,4 @@
-module SeveralFailingWithComments exposing (testExpectations, testFailingFuzzTests, {- hello -} testWithoutNums, withoutNums)
+module SeveralWithCommentsFailing exposing (testExpectations, testFailingFuzzTests, {- hello -} testWithoutNums, withoutNums)
 
 import Char
 import Expect

--- a/tests/SplitSocketMessageFailing.elm
+++ b/tests/SplitSocketMessageFailing.elm
@@ -1,0 +1,25 @@
+module SplitSocketMessageFailing exposing (..)
+
+import Expect exposing (Expectation)
+import Test exposing (..)
+import Array.Hamt as Array
+
+
+{- This is a regression test.
+
+   For some reason, the failure output of this specific test ends up being read
+   from the socket in 2 separate chunks. This breaks our assumption and leads to
+   a crash.
+
+   I'm not sure to what degree this can be reproduced on platforms _other_ than
+   OSX.
+-}
+
+
+suite : Test
+suite =
+    test "scce" <|
+        \_ ->
+            Expect.equal
+                (Array.repeat 1 0)
+                (Array.repeat 49 0)

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -9,10 +9,12 @@ var elmTest = "elm-test";
 
 function run(testFile) {
   if (!testFile) {
-    echo("Running: elm-test");
-    return exec(elmTest).code;
+    var cmd = [elmTest, "--color"].join(" ");
+
+    echo("Running: " + cmd);
+    return exec(cmd).code;
   } else {
-    var cmd = [elmTest, testFile].join(" ");
+    var cmd = [elmTest, testFile, "--color"].join(" ");
 
     echo("Running: " + cmd);
     return exec(cmd).code;
@@ -121,6 +123,8 @@ assertTestSuccess(path.join("tests", "*Pass*"));
 assertTestFailure(path.join("tests", "*Fail*"));
 assertTestFailure();
 
+cd("../");
+
 ls("tests/*.elm").forEach(function(testToRun) {
   if (/Passing\.elm$/.test(testToRun)) {
     echo("\n### Testing " + testToRun + " (expecting it to pass)\n");
@@ -135,6 +139,9 @@ ls("tests/*.elm").forEach(function(testToRun) {
         " (expecting it to error with a runtime exception)\n"
     );
     assertTestErrored(testToRun);
+  } else if (/Port\d.elm$/.test(testToRun)){
+    echo("\n### Skipping " + testToRun + " (helper file)\n");
+    return;
   } else {
     echo(
       "Tried to run " +
@@ -144,8 +151,6 @@ ls("tests/*.elm").forEach(function(testToRun) {
     process.exit(1);
   }
 });
-
-cd("..");
 
 echo("### Testing elm-test init && elm-test");
 rm("-Rf", "tmp");

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -11,7 +11,8 @@
     "dependencies": {
         "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
         "elm-community/string-extra": "1.3.3 <= v < 2.0.0",
-        "elm-lang/core": "5.0.0 <= v < 6.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "Skinney/elm-array-exploration": "2.0.5 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/tests/finder.js
+++ b/tests/finder.js
@@ -4,7 +4,7 @@ const finder = require("../lib/finder.js");
 describe("finder", function() {
   it("should initialize okay twice in a row", done => {
     finder
-      .readExposing(__dirname + "/SeveralFailingWithComments.elm")
+      .readExposing(__dirname + "/SeveralWithCommentsFailing.elm")
       .then(exposedFunctions => {
         assert.deepEqual(exposedFunctions, [
           "testExpectations",


### PR DESCRIPTION
A single `socket.write` does not always result in a single
`socket.on('data')` event being triggered. The way this has manifested
in the past has been by multiple messages being concatenated into a
single message. To that end, the current strategy is to join messages
into an array by appending `,` on the sending side and transforming that
on the receiving side.

However, a new, [reproducible case][repr] has popped up where the inverse is
happening: a single write resulting in 2 separate chunks of data coming
in. This isn't really something we can handle with the current strategy.

Turns out that this is essentially a solved problem: the `split` package
exports a `split()` function that a socket can be piped through and
which does all the bookkeeping to split chunks into proper messages.

So the new strategy is `append a newline`, and `split on newlines`. All
in all, this looks more like plain old json-lines.

[repr]: https://github.com/magopian/elm-scce