### PR TITLE
Allow running multiple instances of elm-test in parallel

### DIFF
--- a/lib/pipe-filename.js
+++ b/lib/pipe-filename.js
@@ -1,3 +1,5 @@
 //@flow
 module.exports =
-  process.platform === "win32" ? "\\\\.\\pipe\\elm_test" : "/tmp/elm_test.sock";
+  process.platform === "win32"
+    ? "\\\\.\\pipe\\elm_test-" + process.pid
+    : "/tmp/elm_test-" + process.pid + ".sock";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.18.10",
+  "version": "0.18.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Using the process ID of the main process in the name of the sockets
means multiple parallel instances of elm-test won't clash or try to
use the same socket across multiple processes.

Should take care of @smucode's issue in #219