### PR TITLE
Allow directories other than "test" or "tests"

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -310,7 +310,7 @@ function runElmTest() {
     );
 
     getGlobs = function() {
-      return globifyWithRoot(root, "test?(s)/**/*.elm");
+      return globifyWithRoot(root, "**/*.elm");
     };
   }
   var globs = getGlobs();
@@ -333,13 +333,6 @@ function runElmTest() {
     Runner.findNearestElmPackageDir([path.resolve(testRootDir, "..")])
   );
   elmPackagePath = path.resolve(path.join(testRootDir, "elm-package.json"));
-
-  if (testRootDir === originalDir) {
-    console.error(
-      "It looks like you're running elm-test from within your tests directory.\n\nPlease run elm-test from your project's root directory, where its elm-package.json lives!"
-    );
-    process.exit(1);
-  }
 
   process.chdir(testRootDir);
 


### PR DESCRIPTION
Given the following file structure:

```
src/
    Nested/
        Tests.elm
elm-package.json
```

I would expect to be able to run `elm-test src/Nested/Tests.elm` to run any tests in that file. However this currently isn't allowed because it isn't in the `test` or `tests` directory. Errors like this are thrown:

```sh
[1] % elm-test src/Nested/Tests.elm
It looks like you're running elm-test from within your tests directory.

Please run elm-test from your project's root directory, where its elm-package.json lives!
```

With the changes in this PR I was able to run tests successfully, but I have a feeling there's still some work to do with ignoring nested `node_modules` and `elm-stuff` directories.
