### PR TITLE
Fix `--watch`

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -118,6 +118,12 @@ function run(
     var stream = socket.pipe(split());
 
     stream.on("data", function(data) {
+      // In watch mode, the socket is drained which results in an extraneous
+      // message being sent. If we receive no data, ignore it.
+      if (!data) {
+        return;
+      }
+
       var response = JSON.parse(data);
 
       switch (response.type) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.18.11",
+  "version": "0.18.12-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
When a worker is done, the socket is `drain`ed.

This results in an extra albeit empty message being received.
Previously, the "make it an array" made this invisible, but now that we
split on newlines, we attempt to `JSON.parse` an empty
string.

So, easy fix: ignore empty messages.

Resolves #234