### PR TITLE
🤞 Keep going when `elm-package install` fails

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -519,13 +519,12 @@ function ensurePackagesInstalled(dir) {
           Object.assign({}, processOpts, { cwd: dir }),
           function(childErr) {
             if (childErr) {
-              reject(
+              infoLog(
                 "Warning: Unable to complete missing packages check - " +
                   childErr.message
               );
-            } else {
-              resolve();
             }
+            resolve();
           }
         );
       }


### PR DESCRIPTION
Rationale: `elm-package install --yes` can fail for a bunch of reasons, but this isn't necessarily a show-stopper. It has happened before that package.elm-lang.org was out, for example. GitHub can also be silly, occasionally. When developing locally or testing on CI with cached `elm-stuff`, this means that compilation and testing could stuff succeed.

If things are truly messed up (missing required dependencies), `elm-make` will error out. Combined with a printed warning about failing to run `elm-package install`, this seems like a good compromise: the user is still informed so they know _why_ the tests failed to run, and we don't block people from testing when things outside their control aren't behaving as assumed.