### PR TITLE
fix typo file => filePath

### DIFF
--- a/lib/finder.js
+++ b/lib/finder.js
@@ -1,9 +1,9 @@
 var fs = require("fs-extra");
 
-function readExposing(file) {
+function readExposing(filePath) {
   return new Promise(function(resolve, reject) {
     // read 60 chars at a time. roughly optimal: memory vs performance
-    var stream = fs.createReadStream(file, {
+    var stream = fs.createReadStream(filePath, {
       encoding: "utf8",
       highWaterMark: 8 * 60
     });


### PR DESCRIPTION
in the error message below it's called `filePath`, which didn't exist