### PR TITLE
Fix encodeReasonType in JsonReporter

### DIFF
--- a/src/Test/Reporter/Json.elm
+++ b/src/Test/Reporter/Json.elm
@@ -95,7 +95,7 @@ encodeFailure { given, description, reason } =
 encodeReasonType : String -> Value -> Value
 encodeReasonType reasonType data =
     Encode.object
-        [ ( "type", Encode.string "custom" ), ( "data", data ) ]
+        [ ( "type", Encode.string reasonType ), ( "data", data ) ]
 
 
 encodeReason : String -> Reason -> Value


### PR DESCRIPTION
Thanks for this project. We have some users [wanting to use Elm](https://github.com/Codewars/codewars-runner-cli/issues/520) and this will be very helpful.

This PR fixes the issue where failure reason's `type` is always set to `"custom"`, making it difficult to use the `data`.