### PR TITLE
Display elm-make's error message when it fails to compile when using a machine readable reporter

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -402,7 +402,7 @@ function isMachineReadableReporter(reporter) {
 
 function processOptsForReporter(reporter) {
   if (isMachineReadableReporter(reporter)) {
-    return { stdio: ["ignore", "ignore", "pipe"] };
+    return { stdio: ["ignore", "ignore", process.stderr] };
   } else {
     return {};
   }

--- a/tests/compile-error-test/InvalidSyntax.elm
+++ b/tests/compile-error-test/InvalidSyntax.elm
@@ -1,0 +1,3 @@
+module InvalidSyntax exposing(..)
+
+{-

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -106,6 +106,16 @@ describe("flags", () => {
         done();
       });
     }).timeout(60000);
+
+    it("Should be able to report compilation errors", () => {
+      const runResult = shell.exec(
+        "elm-test --report=junit tests/compile-error-test/InvalidSyntax.elm",
+        { silent: true }
+      );
+
+      assert.ok(runResult.stderr.match(/SYNTAX PROBLEM/));
+    }).timeout(60000);
+
     it("Should be able to report failing junit xml", done => {
       const runResult = shell.exec(
         "elm-test --report=junit tests/OneFailing.elm",


### PR DESCRIPTION
### Before

```sh
$ PATH=$(pwd)/node_modules/.bin:$PATH elm-test tests/compile-error-test/InvalidSyntax.elm --report junit >/dev/null
Compilation failed while attempting to build /path/to/node-test-runner/tests/compile-error-test/InvalidSyntax.elm
```

### After

```sh
$ PATH=$(pwd)/node_modules/.bin:$PATH elm-test tests/compile-error-test/InvalidSyntax.elm --report junit >/dev/null
-- SYNTAX PROBLEM - /path/to/node-test-runner/tests/compile-error-test/InvalidSyntax.elm

I ran into something unexpected when parsing your code!


I am looking for one of the following things:

    whitespace

Compilation failed while attempting to build /path/to/node-test-runner/tests/compile-error-test/InvalidSyntax.elm
```

I guess this is the behavior that was intended when [#155](https://github.com/rtfeldman/node-test-runner/pull/155/files#diff-a9fdbb49f32181e82baf5d2d40812e23R320) introduced `processOptsForReporter`, but hasn't been working as intended.

This change will also make it so that stderr content of `elm-package` will be displayed, which I think is fine: https://github.com/rtfeldman/node-test-runner/blob/87d8aa1b2805914da8f64e4005e5bf6ff9f8e06f/lib/elm-test.js#L514-L515