### PR TITLE
fixes crash when running elm-test on a package in windows

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -552,7 +552,7 @@ function generatePackageJson(filePathArgs) {
 }
 
 function askElmForMissingTransitiveDependencies(pathtoElmProject) {
-  var result = child_process.spawnSync(pathToElmBinary, ["make", "--report=json"], {
+  var result = spawn.sync(pathToElmBinary, ["make", "--report=json"], {
     silent: true,
     cwd: pathtoElmProject
   });


### PR DESCRIPTION
A call to `child_process.spawnSync` was crashing on windows with the following error. This only happens with a package, not with an application.

```
>elm-test
Unhandled exception while running the tests: TypeError: Cannot read property 'toString' of null
    at askElmForMissingTransitiveDependencies (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\lib\elm-test.js:554:30)
    at generatePackageJson (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\lib\elm-test.js:498:23)
    at runElmTest (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\lib\elm-test.js:331:22)
    at Object.<anonymous> (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\lib\elm-test.js:785:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\bin\elm-test:3:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:266:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)
```

The underlying error was:

```
result { error:
   { Error: spawnSync elm ENOENT
       at Object.spawnSync (internal/child_process.js:982:20)
       at Object.spawnSync (child_process.js:585:24)
       at askElmForMissingTransitiveDependencies (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\lib\elm-test.js:548:30)
       at generatePackageJson (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\lib\elm-test.js:498:23)
       at runElmTest (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\lib\elm-test.js:331:22)
       at Object.<anonymous> (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\lib\elm-test.js:786:1)
       at Module._compile (internal/modules/cjs/loader.js:689:30)
       at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
       at Module.load (internal/modules/cjs/loader.js:599:32)
       at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
       at Function.Module._load (internal/modules/cjs/loader.js:530:3)
       at Module.require (internal/modules/cjs/loader.js:637:17)
       at require (internal/modules/cjs/helpers.js:20:18)
       at Object.<anonymous> (C:\Users\harm\AppData\Roaming\nvm\v10.8.0\node_modules\elm-test\bin\elm-test:3:1)
       at Module._compile (internal/modules/cjs/loader.js:689:30)
       at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
       at Module.load (internal/modules/cjs/loader.js:599:32)
       at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
       at Function.Module._load (internal/modules/cjs/loader.js:530:3)
       at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
       at startup (internal/bootstrap/node.js:266:19)
       at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)
     errno: 'ENOENT',
     code: 'ENOENT',
     syscall: 'spawnSync elm',
     path: 'elm',
     spawnargs: [ 'make', '--report=json' ] },
  status: null,
  signal: null,
  output: null,
  pid: 0,
  stdout: null,
  stderr: null }
```

Solved it by using `cross-spawn` instead of `child_process.spawn`. `cross-spawn` was already used elsewhere in the file.

slack discussion: https://elmlang.slack.com/archives/C0CLGCMMF/p1535786706000100