### PR TITLE
Extract Compile and Generate modules

### DIFF
--- a/lib/Compile.js
+++ b/lib/Compile.js
@@ -1,0 +1,99 @@
+//@flow
+
+const path = require("path"),
+  elmCompiler = require("node-elm-compiler"),
+  spawn = require("cross-spawn");
+
+function compile(
+  testFile/*:string*/,
+  projectRootDir/*:string*/,
+  verbose/*:boolean*/,
+  pathToElmBinary/*:string*/,
+  report/*:string*/
+) {
+  return new Promise((resolve, reject) => {
+    const generatedCodeDir = path.resolve(
+      path.join(projectRootDir, "elm-stuff", "generated-code", "elm-explorations", "test")
+    );
+    const dest = path.resolve(path.join(generatedCodeDir, "elmTestOutput.js"));
+
+    const compileProcess = elmCompiler.compile([testFile], {
+      output: dest,
+      verbose: verbose,
+      spawn: spawnCompiler(report),
+      pathToElm: pathToElmBinary,
+      processOpts: processOptsForReporter(report)
+    });
+
+    compileProcess.on("close", function(exitCode) {
+      if (exitCode !== 0) {
+        reject("Compilation failed");
+      } else {
+        resolve(dest);
+      }
+    });
+  });
+}
+
+function compileAll(
+    testFilePaths/*:Array<string>*/,
+    generatedCodeDir/*:string*/,
+    verbose/*:boolean*/,
+    pathToElmBinary/*:string*/,
+    report/*:string*/
+  ) {
+  return new Promise((resolve, reject) => {
+    const compileProcess = elmCompiler.compile(testFilePaths, {
+      output: "/dev/null",
+      cwd: generatedCodeDir,
+      verbose: verbose,
+      spawn: spawnCompiler(report),
+      pathToElm: pathToElmBinary,
+      processOpts: processOptsForReporter(report)
+    });
+
+    compileProcess.on("close", function(exitCode) {
+      if (exitCode === 0) {
+        resolve();
+      } else {
+        reject(
+          "Compilation failed while attempting to build "
+            + testFilePaths.join(" ")
+        );
+      }
+    });
+  });
+}
+
+function spawnCompiler(report /*:string*/) {
+  return (pathToElm /*:string*/, processArgs/*:Array<string>*/, processOpts) => {
+    const finalOpts = Object.assign({},
+      processOpts,
+      {
+        stdio: [
+          process.stdin,
+          report === "console" ? process.stdout : "ignore",
+          process.stderr
+        ]
+      }
+    );
+
+    return spawn(pathToElm, processArgs, finalOpts);
+  }
+}
+
+function processOptsForReporter(reporter) {
+  if (isMachineReadableReporter(reporter)) {
+    return { stdio: ["ignore", "ignore", process.stderr] };
+  } else {
+    return {};
+  }
+}
+
+function isMachineReadableReporter(reporter/*:string*/) {
+  return reporter === "json" || reporter === "junit";
+}
+
+
+module.exports = {compile, compileAll, isMachineReadableReporter};
+

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -1,0 +1,43 @@
+// @flow
+
+const path = require("path"),
+  spawn = require("cross-spawn"),
+  fs = require("fs-extra"),
+  pipeFilename = require("./pipe-filename.js");
+
+function prepareCompiledJsFile(dest/*:string*/) {
+  return Promise.all([
+    readUtf8(path.join(__dirname, "..", "templates", "before.js")),
+    readUtf8(dest),
+    readUtf8(path.join(__dirname, "..", "templates", "after.js"))
+  ]).then(([before, content, after]) => {
+    const finalContent = [
+      before,
+      "var Elm = (function(module) { ",
+      content,
+      "return this.Elm;",
+      "})({});",
+      "var pipeFilename = " + JSON.stringify(pipeFilename) + ";",
+      after
+    ].join("\n");
+
+    return fs.writeFile(dest, finalContent);
+  });
+}
+
+function readUtf8(filepath) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filepath, {encoding: "utf8"}, (err, contents) =>
+      {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(contents);
+        }
+      }
+    );
+  });
+}
+
+module.exports = {prepareCompiledJsFile};
+

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -5,6 +5,8 @@ var pipeFilename = require("./pipe-filename.js");
 var chalk = require("chalk");
 var Version = require("./version.js");
 var Install = require("./install.js");
+var Compile = require("./Compile.js");
+var Generate = require("./Generate.js");
 var dns = require("dns");
 var processTitle = "elm-test";
 
@@ -158,66 +160,24 @@ var generatedCodeDir = path.resolve(
 );
 
 function runTests(testFile) {
-  return new Promise(function(resolve, reject) {
-    var dest = path.resolve(path.join(generatedCodeDir, "elmTestOutput.js"));
-
-    var compileProcess = compile([testFile], {
-      output: dest,
-      verbose: args.verbose,
-      spawn: spawnCompiler,
-      pathToElm: pathToElmBinary,
-      warn: args.warn,
-      processOpts: processOptsForReporter(args.report)
+  return Compile.compile(
+    testFile, projectRootDir, args.verbose, pathToElmBinary, args.report
+  ).then(function(dest) {
+    return Generate.prepareCompiledJsFile(dest).then(function() {
+      return Promise.resolve(Supervisor.run(
+        packageInfo.version,
+        report,
+        processes,
+        dest,
+        args.watch,
+        Compile.isMachineReadableReporter(report)
+      ));
     });
-
-    compileProcess.on("close", function(exitCode) {
-      if (exitCode !== 0) {
-        console.error("Compilation failed for", testFile);
-        if (!args.watch) {
-          process.exit(exitCode);
-        } else {
-          resolve();
-        }
-      } else {
-        prepareCompiledJsFile(dest);
-
-        Supervisor.run(
-          packageInfo.version,
-          report,
-          processes,
-          dest,
-          args.watch,
-          isMachineReadableReporter(report)
-          )
-            .then(resolve);
-      }
-    });
+  })
+  .catch(function(exitCode) {
+    console.error("Compilation failed for", testFile);
+    return Promise.reject(exitCode);
   });
-}
-
-function prepareCompiledJsFile(dest) {
-  // TODO read files in parallel using Promise.all
-  var before = fs.readFileSync(
-    path.join(__dirname, "..", "templates", "before.js"),
-    "utf8"
-  );
-  var after = fs.readFileSync(
-    path.join(__dirname, "..", "templates", "after.js"),
-    "utf8"
-  );
-  var content = fs.readFileSync(dest, "utf8");
-
-  var finalContent = [
-    before,
-    "var Elm = (function(module) { ",
-    content,
-    "return this.Elm;",
-    "})({});",
-    "var pipeFilename = " + JSON.stringify(pipeFilename) + ";",
-    after
-  ].join("\n");
-
-  fs.writeFileSync(dest, finalContent);
 }
 
 function checkNodeVersion() {
@@ -308,40 +268,42 @@ function runElmTest() {
 
   function run() {
     var testFilePaths = _.flatMap(globs, resolveFilePath);
-    return compileAllTests(testFilePaths)
-      .then(function() {
-        return Runner.findTests(
-          generatedCodeDir,
-          testFilePaths,
-          sourceDirs,
-          !isMachineReadableReporter(report)
-        )
-          .then(function(runnableTests) {
-            process.chdir(generatedCodeDir);
+  // This compiles all the tests so that we generate *.elmi files for them,
+  // which we can then read to determine which tests need to be run.
+  return Compile.compileAll(testFilePaths, generatedCodeDir, args.verbose, pathToElmBinary, args.report)
+    .then(function() {
+      return Runner.findTests(
+        generatedCodeDir,
+        testFilePaths,
+        sourceDirs,
+        !Compile.isMachineReadableReporter(report)
+      )
+        .then(function(runnableTests) {
+          process.chdir(generatedCodeDir);
 
-            return generateAndRunTests(
-              runnableTests,
-              filePathArgs,
-              generatedSrc,
-              getGlobs
-            );
-          })
-          .catch(function(err) {
+          return generateAndRunTests(
+            runnableTests,
+            filePathArgs,
+            generatedSrc,
+            getGlobs
+          );
+        })
+        .catch(function(err) {
             console.error(err);
             process.exit(1);
           });
-      })
-      .catch(function(err) {
-        console.error(err);
-        if (!args.watch) {
-          process.exit(1);
-        } else {
-          console.log();
-        }
-      })
-      .then(function() {
-        console.log(chalk.blue("Watching for changes..."));
-      })
+        })
+    .catch(function(err) {
+      console.error(err);
+      if (!args.watch) {
+        process.exit(1);
+      } else {
+        console.log();
+      }
+    })
+    .then(function() {
+      console.log(chalk.blue("Watching for changes..."));
+    })
   }
 
   var currentRun = run();
@@ -376,45 +338,6 @@ function runElmTest() {
       currentRun = currentRun.then(run);
     });
   }
-}
-
-function isMachineReadableReporter(reporter) {
-  return reporter === "json" || reporter === "junit";
-}
-
-function processOptsForReporter(reporter) {
-  if (isMachineReadableReporter(reporter)) {
-    return { stdio: ["ignore", "ignore", process.stderr] };
-  } else {
-    return {};
-  }
-}
-
-// This compiles all the tests so that we generate *.elmi files for them,
-// which we can then read to determine which tests need to be run.
-function compileAllTests(testFilePaths) {
-  return new Promise(function(resolve, reject) {
-    process.chdir(generatedCodeDir);
-    var compileProcess = compile(testFilePaths, {
-      output: "/dev/null",
-      verbose: args.verbose,
-      spawn: spawnCompiler,
-      pathToElm: pathToElmBinary,
-      warn: args.warn,
-      processOpts: processOptsForReporter(args.report)
-    });
-
-    compileProcess.on("close", function(exitCode) {
-      if (exitCode !== 0) {
-        reject(
-          "Compilation failed while attempting to build " +
-            testFilePaths.join(" ")
-        );
-      } else {
-        resolve();
-      }
-    });
-  });
 }
 
 function generatePackageJson(filePathArgs) {
@@ -750,21 +673,6 @@ function infoLog(msg) {
   if (report === "console") {
     console.log(msg);
   }
-}
-
-function spawnCompiler(cmd, args, opts) {
-  var compilerOpts = _.defaults(
-    {
-      stdio: [
-        process.stdin,
-        report === "console" ? process.stdout : "ignore",
-        process.stderr
-      ]
-    },
-    opts
-  );
-
-  return spawn(cmd, args, compilerOpts);
 }
 
 runElmTest();


### PR DESCRIPTION
I figured out a solution for https://github.com/rtfeldman/node-test-runner/issues/275 but it requires restructuring a bunch of stuff, so I'm starting with some refactors to detangle some things first.

This extracts the `Compile` and `Generate` modules. It also switches to using `Promise.all` for reading `before.js`, `after.js`, and the compiled content itself, which should theoretically be a slight performance improvement over reading them synchronously.