### PR TITLE
watch: prevent process exit, add debouncing, handle new/removed files.

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -2,6 +2,7 @@
 
 var packageInfo = require("../package.json");
 var pipeFilename = require("./pipe-filename.js");
+var chalk = require("chalk");
 var Version = require("./version.js");
 var Install = require("./install.js");
 var dns = require("dns");
@@ -157,35 +158,40 @@ var generatedCodeDir = path.resolve(
 );
 
 function runTests(testFile) {
-  var dest = path.resolve(path.join(generatedCodeDir, "elmTestOutput.js"));
+  return new Promise(function(resolve, reject) {
+    var dest = path.resolve(path.join(generatedCodeDir, "elmTestOutput.js"));
 
-  var compileProcess = compile([testFile], {
-    output: dest,
-    verbose: args.verbose,
-    spawn: spawnCompiler,
-    pathToElm: pathToElmBinary,
-    warn: args.warn,
-    processOpts: processOptsForReporter(args.report)
-  });
+    var compileProcess = compile([testFile], {
+      output: dest,
+      verbose: args.verbose,
+      spawn: spawnCompiler,
+      pathToElm: pathToElmBinary,
+      warn: args.warn,
+      processOpts: processOptsForReporter(args.report)
+    });
 
-  compileProcess.on("close", function(exitCode) {
-    if (exitCode !== 0) {
-      console.error("Compilation failed for", testFile);
-      if (!args.watch) {
-        process.exit(exitCode);
+    compileProcess.on("close", function(exitCode) {
+      if (exitCode !== 0) {
+        console.error("Compilation failed for", testFile);
+        if (!args.watch) {
+          process.exit(exitCode);
+        } else {
+          resolve();
+        }
+      } else {
+        prepareCompiledJsFile(dest);
+
+        Supervisor.run(
+          packageInfo.version,
+          report,
+          processes,
+          dest,
+          args.watch,
+          isMachineReadableReporter(report)
+          )
+            .then(resolve);
       }
-    } else {
-      prepareCompiledJsFile(dest);
-
-      Supervisor.run(
-        packageInfo.version,
-        report,
-        processes,
-        dest,
-        args.watch,
-        isMachineReadableReporter(report)
-      );
-    }
+    });
   });
 }
 
@@ -234,7 +240,8 @@ function globify(filename) {
   return glob.sync(filename, {
     nocase: true,
     ignore: "**/elm-stuff/**",
-    nodir: false
+    nodir: false,
+    absolute: true
   });
 }
 
@@ -243,7 +250,8 @@ function globifyWithRoot(root, filename) {
     root: root,
     nocase: true,
     ignore: "**/elm-stuff/**",
-    nodir: false
+    nodir: false,
+    absolute: true
   });
 }
 
@@ -271,9 +279,9 @@ function runElmTest() {
     };
   }
   var globs = getGlobs();
-  var testFilePaths = _.flatMap(globs, resolveFilePath);
+  var initialTestFilePaths = _.flatMap(globs, resolveFilePath);
 
-  if (testFilePaths.length === 0) {
+  if (initialTestFilePaths.length === 0) {
     var errorMessage =
       filePathArgs.length > 0
         ? 'No tests found for the file pattern "' +
@@ -285,7 +293,7 @@ function runElmTest() {
     process.exit(1);
   }
 
-  projectRootDir = path.resolve(Runner.findNearestElmPackageDir(testFilePaths));
+  projectRootDir = path.resolve(Runner.findNearestElmPackageDir(initialTestFilePaths));
   testRootDir = path.resolve(path.join(projectRootDir, "tests"));
   generatedCodeDir = path.resolve(
     path.join(projectRootDir, "elm-stuff", "generated-code", "elm-explorations", "test")
@@ -298,33 +306,76 @@ function runElmTest() {
   var generatedSrc = returnValues[0];
   var sourceDirs = returnValues[1];
 
-  return compileAllTests(testFilePaths)
-    .then(function() {
-      return Runner.findTests(
-        generatedCodeDir,
-        testFilePaths,
-        sourceDirs,
-        !isMachineReadableReporter(report)
-      )
-        .then(function(runnableTests) {
-          process.chdir(generatedCodeDir);
+  function run() {
+    var testFilePaths = _.flatMap(globs, resolveFilePath);
+    return compileAllTests(testFilePaths)
+      .then(function() {
+        return Runner.findTests(
+          generatedCodeDir,
+          testFilePaths,
+          sourceDirs,
+          !isMachineReadableReporter(report)
+        )
+          .then(function(runnableTests) {
+            process.chdir(generatedCodeDir);
 
-          generateAndRunTests(
-            runnableTests,
-            filePathArgs,
-            generatedSrc,
-            getGlobs
-          );
-        })
-        .catch(function(err) {
-          console.error(err);
+            return generateAndRunTests(
+              runnableTests,
+              filePathArgs,
+              generatedSrc,
+              getGlobs
+            );
+          })
+          .catch(function(err) {
+            console.error(err);
+            process.exit(1);
+          });
+      })
+      .catch(function(err) {
+        console.error(err);
+        if (!args.watch) {
           process.exit(1);
-        });
-    })
-    .catch(function(err) {
-      console.error(err);
-      process.exit(1);
+        } else {
+          console.log();
+        }
+      })
+      .then(function() {
+        console.log(chalk.blue("Watching for changes..."));
+      })
+  }
+
+  var currentRun = run();
+
+  if (args.watch) {
+    infoLog("Running in watch mode");
+
+    var watchedPaths = getWatchPaths(projectRootDir);
+    var watcher = chokidar.watch(watchedPaths, {
+      awaitWriteFinish: {
+        stabilityThreshold: 500
+      },
+      ignoreInitial: true,
+      ignored: /(\/|^)elm-stuff(\/|$)/
     });
+
+    var eventNameMap = {
+      add: "added",
+      addDir: "added",
+      change: "changed",
+      unlink: "removed",
+      unlinkDir: "removed"
+    };
+
+    watcher.on("all", function(event, filePath) {
+      var relativePath = path.relative(testRootDir, filePath);
+      var eventName = eventNameMap[event] || event;
+
+      infoLog("\n" + relativePath + " " + eventName + ". Rebuilding!");
+
+      // TODO if a previous run is in progress, wait until it's done.
+      currentRun = currentRun.then(run);
+    });
+  }
 }
 
 function isMachineReadableReporter(reporter) {
@@ -660,38 +711,7 @@ function generateAndRunTests(tests, filePathArgs, generatedSrc, getGlobs) {
   // if some of Main's dependencies (such as an individual test file) changed.
   fs.writeFileSync(mainFile, testFileContents);
 
-  if (args.watch) {
-    infoLog("Running in watch mode");
-
-    var watchedPaths = getWatchPaths(projectRootDir);
-    var watcher = chokidar.watch(watchedPaths, {
-      awaitWriteFinish: {
-        stabilityThreshold: 500
-      },
-      ignoreInitial: true,
-      ignored: /(\/|^)elm-stuff(\/|$)/
-    });
-
-    var eventNameMap = {
-      add: "added",
-      addDir: "added",
-      change: "changed",
-      unlink: "removed",
-      unlinkDir: "removed"
-    };
-
-    watcher.on("all", function(event, filePath) {
-      var relativePath = path.relative(testRootDir, filePath);
-      var eventName = eventNameMap[event] || event;
-
-      infoLog("\n" + relativePath + " " + eventName + ". Rebuilding!");
-
-      // TODO if a previous run is in progress, wait until it's done.
-      runTests(mainFile);
-    });
-  }
-
-  runTests(mainFile);
+  return runTests(mainFile);
 }
 
 function getWatchPaths(projectRootDir) {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -1,6 +1,6 @@
 // @flow
 
-var chalk = require("chalk"), // Chalk is used only for the "Watching for changes..." message
+var chalk = require("chalk"),
   XmlBuilder = require("xmlbuilder"),
   _ = require("lodash"),
   fs = require("fs-extra"),
@@ -17,242 +17,245 @@ function run(
   watch /*:boolean*/,
   isMachineReadable /*:boolean*/
 ) {
-  var nextResultToPrint = null;
-  var finishedWorkers = 0;
-  var closedWorkers = 0;
-  var results = new Map();
-  var failures = 0;
-  var todos = [];
-  var testsToRun = -1;
-  var initializedWorkers = -1;
-  var startingTime = Date.now();
-  var workers = [];
+  return new Promise(function(resolve, reject) {
+    var nextResultToPrint = null;
+    var finishedWorkers = 0;
+    var closedWorkers = 0;
+    var results = new Map();
+    var failures = 0;
+    var todos = [];
+    var testsToRun = -1;
+    var initializedWorkers = -1;
+    var startingTime = Date.now();
+    var workers = [];
 
-  function printResult(result) {
-    if (format === "console") {
-      // todos are objects, and will be shown in the SUMMARY only.
-      // passed tests are nulls, and should not be printed.
-      // failed tests are strings.
-      if (typeof result === "string") {
-        console.log(makeWindowsSafe(result));
+    function printResult(result) {
+      if (format === "console") {
+        // todos are objects, and will be shown in the SUMMARY only.
+        // passed tests are nulls, and should not be printed.
+        // failed tests are strings.
+        if (typeof result === "string") {
+          console.log(makeWindowsSafe(result));
+        }
+      } else if (format === "json") {
+        console.log(JSON.stringify(result));
       }
-    } else if (format === "json") {
-      console.log(JSON.stringify(result));
+      // JUnit does everything at once in SUMMARY, elsewhere
     }
-    // JUnit does everything at once in SUMMARY, elsewhere
-  }
 
-  function flushResults() {
-    // Only print any results if we're ready - that is, nextResultToPrint
-    // is no longer null. (BEGIN changes it from null to 0.)
-    if (nextResultToPrint !== null) {
-      var result = results.get(nextResultToPrint);
+    function flushResults() {
+      // Only print any results if we're ready - that is, nextResultToPrint
+      // is no longer null. (BEGIN changes it from null to 0.)
+      if (nextResultToPrint !== null) {
+        var result = results.get(nextResultToPrint);
 
-      while (
-        // If there are no more results to print, then we're done.
-        nextResultToPrint < testsToRun &&
-        // Otherwise, keep going until we have no result available to print.
-        typeof result !== "undefined"
-      ) {
-        printResult(result);
-        nextResultToPrint++;
-        result = results.get(nextResultToPrint);
+        while (
+          // If there are no more results to print, then we're done.
+          nextResultToPrint < testsToRun &&
+          // Otherwise, keep going until we have no result available to print.
+          typeof result !== "undefined"
+        ) {
+          printResult(result);
+          nextResultToPrint++;
+          result = results.get(nextResultToPrint);
+        }
       }
     }
-  }
-  function reportRuntimeException() {
-    console.error(
-      chalk.red(
-        "\n\nThere was an unexpected runtime exception while running tests\n\n"
-      )
-    );
-  }
+    function reportRuntimeException() {
+      console.error(
+        chalk.red(
+          "\n\nThere was an unexpected runtime exception while running tests\n\n"
+        )
+      );
+    }
 
-  function handleResults(response) {
-    // TODO print progress bar - e.g. "Running test 5 of 20" on a bar!
-    // -- yikes, be careful though...test the scenario where test
-    // authors put Debug.log in their tests - does that mess
-    // everything up re: the line feed? Seems like it would...
-    // ...so maybe a bar is not best. Can we do better? Hm.
-    // Maybe the answer is to print the thing, then Immediately
-    // backtrack the line feed, so that if someone else does more
-    // logging, it will overwrite our status update and that's ok?
+    function handleResults(response) {
+      // TODO print progress bar - e.g. "Running test 5 of 20" on a bar!
+      // -- yikes, be careful though...test the scenario where test
+      // authors put Debug.log in their tests - does that mess
+      // everything up re: the line feed? Seems like it would...
+      // ...so maybe a bar is not best. Can we do better? Hm.
+      // Maybe the answer is to print the thing, then Immediately
+      // backtrack the line feed, so that if someone else does more
+      // logging, it will overwrite our status update and that's ok?
 
-    _.each(response.results, function(result, index) {
-      results.set(parseInt(index), result);
+      _.each(response.results, function(result, index) {
+        results.set(parseInt(index), result);
 
-      switch (format) {
-        case "console":
-          if (result === null) {
-            // It's a PASS; no need to take any action.
-          } else if (typeof result.todo !== "undefined") {
-            todos.push(result);
-          } else {
-            failures++;
-          }
-          break;
-        case "junit":
-          if (typeof result.failure !== "undefined") {
-            failures++;
-          }
-          break;
-        case "json":
-          if (result.status === "fail") {
-            failures++;
-          } else if (result.status === "todo") {
-            todos.push({ labels: result.labels, todo: result.failures[0] });
-          }
-          break;
-      }
-    });
-
-    flushResults();
-  }
-
-  function initWorker(socket) {
-    socket.setEncoding("utf8");
-    socket.setNoDelay(true);
-
-    // See the long note near client.write() in worker.js for why we do this.
-    // It fixes a nasty bug!
-    var stream = socket.pipe(split());
-
-    stream.on("data", function(data) {
-      // In watch mode, the socket is drained which results in an extraneous
-      // message being sent. If we receive no data, ignore it.
-      if (!data) {
-        return;
-      }
-
-      var response = JSON.parse(data);
-
-      switch (response.type) {
-        case "FINISHED":
-          handleResults(response);
-
-          // This worker found no tests remaining to run; it's finished!
-          finishedWorkers++;
-
-          // If all the workers have finished, print the summmary.
-          if (finishedWorkers === workers.length) {
-            socket.write(
-              JSON.stringify({
-                type: "SUMMARY",
-                duration: Date.now() - startingTime,
-                failures: failures,
-                todos: todos
-              })
-            );
-          }
-          break;
-        case "SUMMARY":
-          flushResults();
-
-          printResult(response.message);
-
-          if (format === "junit") {
-            var xml = response.message;
-            var values = Array.from(results.values());
-
-            xml.testsuite.testcase = xml.testsuite.testcase.concat(values);
-
-            console.log(XmlBuilder.create(xml).end());
-          }
-
-          if (watch) {
-            // Close all the workers.
-            workers.forEach(function(worker) {
-              worker.kill();
-            });
-          } else {
-            // Don't bother closing workers, because we're exiting immediately.
-            process.exit(response.exitCode);
-          }
-          break;
-        case "BEGIN":
-          testsToRun = response.testCount;
-
-          if (!isMachineReadable) {
-            var headline = "elm-test " + elmTestVersion;
-            var bar = _.repeat("-", headline.length);
-
-            console.log("\n" + headline + "\n" + bar + "\n");
-          }
-
-          printResult(response.message);
-
-          // Now we're ready to print results!
-          nextResultToPrint = 0;
-
-          flushResults();
-
-          break;
-        case "RESULTS":
-          handleResults(response);
-
-          break;
-        case "ERROR":
-          throw new Error(response.message);
-        default:
-          throw new Error("Unrecognized message from worker:" + response.type);
-      }
-    });
-
-    socket.write(JSON.stringify({ type: "TEST", index: initializedWorkers }));
-
-    initializedWorkers++;
-  }
-
-  var pendingException = false,
-    server = net.createServer(initWorker);
-
-  server.on("error", function(err) {
-    console.error(err.stack);
-    server.close();
-  });
-
-  server.on("listening", function() {
-    workers = _.range(0, processes).map(function(index) {
-      var worker = child_process.fork(dest);
-
-      worker.on("close", function(code, signal) {
-        // code can be null.
-        var hasNonZeroExitCode = typeof code === "number" && code !== 0;
-
-        if (watch && !isMachineReadable) {
-          if (hasNonZeroExitCode) {
-            // Queue up complaining about an exception.
-            // Don't print it immediately, or else it might print N times
-            // where N is the number of cores.
-            pendingException = true;
-          }
-          closedWorkers++;
-          // If all the workers have closed, we're done! Continue watching.
-          if (closedWorkers === workers.length) {
-            if (pendingException) {
-              // If we had an exception pending, print it and clear pending flag.
-              reportRuntimeException();
-              pendingException = false;
+        switch (format) {
+          case "console":
+            if (result === null) {
+              // It's a PASS; no need to take any action.
+            } else if (typeof result.todo !== "undefined") {
+              todos.push(result);
+            } else {
+              failures++;
             }
-            console.log(chalk.blue("Watching for changes..."));
-          }
-        } else if (hasNonZeroExitCode) {
-          reportRuntimeException();
-          process.exit(1);
+            break;
+          case "junit":
+            if (typeof result.failure !== "undefined") {
+              failures++;
+            }
+            break;
+          case "json":
+            if (result.status === "fail") {
+              failures++;
+            } else if (result.status === "todo") {
+              todos.push({ labels: result.labels, todo: result.failures[0] });
+            }
+            break;
         }
       });
 
-      return worker;
+      flushResults();
+    }
+
+    function initWorker(socket) {
+      socket.setEncoding("utf8");
+      socket.setNoDelay(true);
+
+      // See the long note near client.write() in worker.js for why we do this.
+      // It fixes a nasty bug!
+      var stream = socket.pipe(split());
+
+      stream.on("data", function(data) {
+        // In watch mode, the socket is drained which results in an extraneous
+        // message being sent. If we receive no data, ignore it.
+        if (!data) {
+          return;
+        }
+
+        var response = JSON.parse(data);
+
+        switch (response.type) {
+          case "FINISHED":
+            handleResults(response);
+
+            // This worker found no tests remaining to run; it's finished!
+            finishedWorkers++;
+
+            // If all the workers have finished, print the summmary.
+            if (finishedWorkers === workers.length) {
+              socket.write(
+                JSON.stringify({
+                  type: "SUMMARY",
+                  duration: Date.now() - startingTime,
+                  failures: failures,
+                  todos: todos
+                })
+              );
+            }
+            break;
+          case "SUMMARY":
+            flushResults();
+
+            printResult(response.message);
+
+            if (format === "junit") {
+              var xml = response.message;
+              var values = Array.from(results.values());
+
+              xml.testsuite.testcase = xml.testsuite.testcase.concat(values);
+
+              console.log(XmlBuilder.create(xml).end());
+            }
+
+            if (watch) {
+              // Close all the workers.
+              workers.forEach(function(worker) {
+                worker.kill();
+              });
+              resolve();
+            } else {
+              // Don't bother closing workers, because we're exiting immediately.
+              process.exit(response.exitCode);
+            }
+            break;
+          case "BEGIN":
+            testsToRun = response.testCount;
+
+            if (!isMachineReadable) {
+              var headline = "elm-test " + elmTestVersion;
+              var bar = _.repeat("-", headline.length);
+
+              console.log("\n" + headline + "\n" + bar + "\n");
+            }
+
+            printResult(response.message);
+
+            // Now we're ready to print results!
+            nextResultToPrint = 0;
+
+            flushResults();
+
+            break;
+          case "RESULTS":
+            handleResults(response);
+
+            break;
+          case "ERROR":
+            throw new Error(response.message);
+          default:
+            throw new Error("Unrecognized message from worker:" + response.type);
+        }
+      });
+
+      socket.write(JSON.stringify({ type: "TEST", index: initializedWorkers }));
+
+      initializedWorkers++;
+    }
+
+    var pendingException = false,
+      server = net.createServer(initWorker);
+
+    server.on("error", function(err) {
+      console.error(err.stack);
+      server.close();
     });
+
+    server.on("listening", function() {
+      workers = _.range(0, processes).map(function(index) {
+        var worker = child_process.fork(dest);
+
+        worker.on("close", function(code, signal) {
+          // code can be null.
+          var hasNonZeroExitCode = typeof code === "number" && code !== 0;
+
+          if (watch && !isMachineReadable) {
+            if (hasNonZeroExitCode) {
+              // Queue up complaining about an exception.
+              // Don't print it immediately, or else it might print N times
+              // where N is the number of cores.
+              pendingException = true;
+            }
+            closedWorkers++;
+            // If all the workers have closed, we're done! Continue watching.
+            if (closedWorkers === workers.length) {
+              if (pendingException) {
+                // If we had an exception pending, print it and clear pending flag.
+                reportRuntimeException();
+                pendingException = false;
+              }
+              resolve();
+            }
+          } else if (hasNonZeroExitCode) {
+            reportRuntimeException();
+            process.exit(1);
+          }
+        });
+
+        return worker;
+      });
+    });
+
+    if (fs.existsSync(pipeFilename) && process.platform !== "win32") {
+      // Never remove named pipes on Windows. The OS will clean them up when
+      // nothing has a handle to them anymore.
+      fs.removeSync(pipeFilename);
+    }
+
+    server.listen(pipeFilename);
   });
-
-  if (fs.existsSync(pipeFilename) && process.platform !== "win32") {
-    // Never remove named pipes on Windows. The OS will clean them up when
-    // nothing has a handle to them anymore.
-    fs.removeSync(pipeFilename);
-  }
-
-  server.listen(pipeFilename);
 }
 
 function makeWindowsSafe(text) {


### PR DESCRIPTION
Fixes #149
Fixes #204

Relevant #242

This commit:
 - Makes some functions return promises so we know when they end.
 - Refactors the file watching logic to re-run more of the testing code.
 - Moves some logging calls around to keep output as it currently is.

**Note**: The tests fail on master so I don't know if they fail _more_ after this commit (I hope not :))