### PR TITLE
Add console clearing on watch mode

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -315,6 +315,12 @@ if (args._[0] === "make") {
   const generatedSrc = returnValues[1];
   const sourceDirs = returnValues[2];
 
+  function clearConsole() {
+    process.stdout.write(
+      process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H'
+    );
+  }
+
   function run() {
     // This compiles all the tests so that we generate *.elmi files for them,
     // which we can then read to determine which tests need to be run.
@@ -360,6 +366,7 @@ if (args._[0] === "make") {
   var currentRun = run();
 
   if (args.watch) {
+    clearConsole();
     infoLog("Running in watch mode");
 
     var watchedPaths = getWatchPaths(projectRootDir);
@@ -382,7 +389,7 @@ if (args._[0] === "make") {
     watcher.on("all", function(event, filePath) {
       var relativePath = path.relative(testRootDir, filePath);
       var eventName = eventNameMap[event] || event;
-
+      clearConsole();
       infoLog("\n" + relativePath + " " + eventName + ". Rebuilding!");
 
       // TODO if a previous run is in progress, wait until it's done.


### PR DESCRIPTION
https://cl.ly/f0ad6cd54e24/sd;lfk.mov

I took this code directly from create-react-app and Jest, it's how they clear the screen.

I'm not sure what the white flashing is on the clear, but I think it's my config rather than this, but haven't dug too much. It's much more pronounced on the screencast than it actually is.

@rtfeldman do you think we want a flag to enable/disable this behaviour?

closes #296 