### PR TITLE
Limit the number of workers on CI

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -62,7 +62,8 @@ var args = minimist(process.argv.slice(2), {
   boolean: ["warn", "version", "help", "watch"],
   string: ["compiler", "seed", "report", "fuzz"]
 });
-var processes = Math.max(1, os.cpus().length);
+const isCI = process.env.CI === "true";
+var processes = Math.max(1, isCI ? 4 : os.cpus().length);
 
 // Recursively search directories for *.elm files, excluding elm-stuff/
 function resolveFilePath(filename) {


### PR DESCRIPTION
@rtfeldman
This is the workaround from https://github.com/rtfeldman/node-test-runner/issues/288#issuecomment-427723129 for #288 and #295. From what I've found so far, macOS on Travis doesn't hang because it only has 2 cores instead of 48 of Linux.

Is this good enough for now to release next beta? I'd like to use #293 soon :)

As I wrote in the comment, one test is broken, but it should be a separate issue.
This build https://travis-ci.org/rtfeldman/node-test-runner/builds/429400712 from your comment 23 days ago shows macOS with Node.js 8 is passing, but I think [the test is actually failing](https://travis-ci.org/rtfeldman/node-test-runner/jobs/429400717#L298-L313) there as well.

![image](https://user-images.githubusercontent.com/639336/46725933-1b1b3880-cc32-11e8-9beb-63cfa3f13a88.png)