### PR TITLE
Read files in parallel

### DIFF
--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -12,28 +12,44 @@ const path = require("path"),
   pipeFilename = require("./pipe-filename.js");
 
 function prepareCompiledJsFile(dest/*:string*/) {
-  // TODO read files in parallel using Promise.all, but BEWARE! Last time I tried this it resulted on elm-test hanging on systems with several cores, e.g. Travis CI and a Linux desktop with a Ryzen CPU. See https://github.com/rtfeldman/node-test-runner/issues/295
-  var before = fs.readFileSync(
-    path.join(__dirname, "..", "templates", "before.js"),
-    "utf8"
-  );
-  var after = fs.readFileSync(
-    path.join(__dirname, "..", "templates", "after.js"),
-    "utf8"
-  );
-  var content = fs.readFileSync(dest, "utf8");
-  var finalContent = [
-    before,
-    "var Elm = (function(module) { ",
-    content,
-    "return this.Elm;",
-    "})({});",
-    "var pipeFilename = " + JSON.stringify(pipeFilename) + ";",
-    after
-  ].join("\n");
-  fs.writeFileSync(dest, finalContent);
+  return Promise.all([
+    readUtf8(path.join(__dirname, "..", "templates", "before.js")),
+    readUtf8(dest),
+    readUtf8(path.join(__dirname, "..", "templates", "after.js"))
+  ]).then(([before, content, after]) => {
+    return new Promise((resolve, reject) => {
+      const finalContent = [
+        before,
+        "var Elm = (function(module) { ",
+        content,
+        "return this.Elm;",
+        "})({});",
+        "var pipeFilename = " + JSON.stringify(pipeFilename) + ";",
+        after
+      ].join("\n");
+      return fs.writeFile(dest, finalContent, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+}
 
-  return Promise.resolve();
+function readUtf8(filepath) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filepath, {encoding: "utf8"}, (err, contents) =>
+      {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(contents);
+        }
+      }
+    );
+  });
 }
 
 function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, pathToElmBinary /*:string*/, filePaths /*:Array<string>*/) {


### PR DESCRIPTION
@rtfeldman I noticed `fs.writeFile`'s callback was missing when I looked at #301. This resolved the hanging on Travis. I can't test "Linux desktop with a Ryzen CPU", but this might be the cause.

https://github.com/rtfeldman/node-test-runner/blob/1bd4416883bfd943bf704d390422372f53323287/lib/Generate.js#L19-L30