### PR TITLE
simplify consecutive pipe on List.map

### DIFF
--- a/fixtures/elm-home/0.19.0/package/elm-explorations/test/1.0.0/tests/src/Helpers.elm
+++ b/fixtures/elm-home/0.19.0/package/elm-explorations/test/1.0.0/tests/src/Helpers.elm
@@ -42,8 +42,7 @@ expectTestToFail test =
         |> Test.Runner.fromTest 100 seed
         |> getRunners
         |> List.concatMap (.run >> (\run -> run ()))
-        |> List.map expectToFail
-        |> List.map always
+        |> List.map (expectToFail >> always)
         |> Expect.all
         |> (\all -> all ())
 

--- a/fixtures/elm-home/0.19.0/package/elm-explorations/test/1.1.0/tests/src/Helpers.elm
+++ b/fixtures/elm-home/0.19.0/package/elm-explorations/test/1.1.0/tests/src/Helpers.elm
@@ -42,8 +42,7 @@ expectTestToFail test =
         |> Test.Runner.fromTest 100 seed
         |> getRunners
         |> List.concatMap (.run >> (\run -> run ()))
-        |> List.map expectToFail
-        |> List.map always
+        |> List.map (expectToFail >> always)
         |> Expect.all
         |> (\all -> all ())
 


### PR DESCRIPTION
I noticed this simplification is possible (based on [elm-lint](https://package.elm-lang.org/packages/jfmengels/elm-lint/2.0.1/Lint-Rules-SimplifyPiping))