### PR TITLE
Only care about tests/ if no globs given

### DIFF
--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -59,14 +59,19 @@ function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, path
   const elmJsonPath = path.resolve(path.join(projectRootDir, "elm.json"));
   const generatedSrc = path.join(generatedCodeDir, "src");
 
-  if (!fs.existsSync(testRootDir)) {
-    console.error("Error: " + testRootDir + " does not exist. Please create a tests/ directory in your project root!");
-    process.exit(1);
-  }
+  const hasBeenGivenFileGlobs = filePaths.length > 0
 
-  if (!fs.lstatSync(testRootDir).isDirectory()) {
-    console.error("Error: " + testRootDir + " exists, but it is not a directory. Please create a tests/ directory in your project root!");
-    process.exit(1);
+  // if we were given file globs, we don't need to check the tests/ directory exists
+  if (hasBeenGivenFileGlobs === false) {
+    if (!fs.existsSync(testRootDir)) {
+      console.error("Error: " + testRootDir + " does not exist. Please create a tests/ directory in your project root!");
+      process.exit(1);
+    }
+
+    if (!fs.lstatSync(testRootDir).isDirectory()) {
+      console.error("Error: " + testRootDir + " exists, but it is not a directory. Please create a tests/ directory in your project root!");
+      process.exit(1);
+    }
   }
 
   fs.mkdirpSync(generatedCodeDir);
@@ -135,7 +140,7 @@ function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, path
     function(src) {
       return path.resolve(path.join(projectRootDir, src));
     }
-  ).concat(testRootDir);
+  ).concat(hasBeenGivenFileGlobs ? [] : [testRootDir]);
 
   testElmJson["source-directories"] = [
     // Include elm-stuff/generated-sources - since we'll be generating sources in there.

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -52,17 +52,15 @@ function readUtf8(filepath) {
   });
 }
 
-function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, pathToElmBinary /*:string*/, filePaths /*:Array<string>*/) {
+function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, pathToElmBinary /*:string*/, filePaths /*:Array<string>*/, hasBeenGivenCustomGlobs /*int*/) {
   const generatedCodeDir = path.resolve(
     path.join(projectRootDir, "elm-stuff", "generated-code", "elm-explorations", "test")
   );
   const elmJsonPath = path.resolve(path.join(projectRootDir, "elm.json"));
   const generatedSrc = path.join(generatedCodeDir, "src");
 
-  const hasBeenGivenFileGlobs = filePaths.length > 0
-
-  // if we were given file globs, we don't need to check the tests/ directory exists
-  if (hasBeenGivenFileGlobs === false) {
+    // if we were given file globs, we don't need to check the tests/ directory exists
+  if (hasBeenGivenCustomGlobs === false) {
     if (!fs.existsSync(testRootDir)) {
       console.error("Error: " + testRootDir + " does not exist. Please create a tests/ directory in your project root!");
       process.exit(1);
@@ -140,7 +138,7 @@ function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, path
     function(src) {
       return path.resolve(path.join(projectRootDir, src));
     }
-  ).concat(hasBeenGivenFileGlobs ? [] : [testRootDir]);
+  ).concat(hasBeenGivenCustomGlobs ? [] : testRootDir);
 
   testElmJson["source-directories"] = [
     // Include elm-stuff/generated-sources - since we'll be generating sources in there.

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -71,8 +71,8 @@ function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, path
 
   // if we were given file globs, we don't need to check the tests/ directory exists
   // this is only for elm applications, which people may need to introduce slowly into their apps
-  // for packages, we stick with the existing behaviour and assume tests are in tests/
-  if (hasBeenGivenCustomGlobs === false && isPackageProject === false) {
+  // for packages, we stick with the existing behaviour and assume tests are in tests/ so do the check always
+  if (hasBeenGivenCustomGlobs === false || isPackageProject === true) {
     if (!fs.existsSync(testRootDir)) {
       console.error("Error: " + testRootDir + " does not exist. Please create a tests/ directory in your project root!");
       process.exit(1);

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -52,7 +52,7 @@ function readUtf8(filepath) {
   });
 }
 
-function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, pathToElmBinary /*:string*/, filePaths /*:Array<string>*/, hasBeenGivenCustomGlobs /*int*/) {
+function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, pathToElmBinary /*:string*/, filePaths /*:Array<string>*/, hasBeenGivenCustomGlobs /*:boolean*/) {
   const generatedCodeDir = path.resolve(
     path.join(projectRootDir, "elm-stuff", "generated-code", "elm-explorations", "test")
   );

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -138,7 +138,7 @@ function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, path
     function(src) {
       return path.resolve(path.join(projectRootDir, src));
     }
-  ).concat(hasBeenGivenCustomGlobs ? [] : testRootDir);
+  ).concat([testRootDir]);
 
   testElmJson["source-directories"] = [
     // Include elm-stuff/generated-sources - since we'll be generating sources in there.

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -59,8 +59,20 @@ function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, path
   const elmJsonPath = path.resolve(path.join(projectRootDir, "elm.json"));
   const generatedSrc = path.join(generatedCodeDir, "src");
 
-    // if we were given file globs, we don't need to check the tests/ directory exists
-  if (hasBeenGivenCustomGlobs === false) {
+  var projectElmJson = {};
+
+  try {
+    projectElmJson = fs.readJsonSync(elmJsonPath);
+  } catch (err) {
+    console.error("Error reading elm.json: " + err);
+    process.exit(1);
+  }
+  var isPackageProject = projectElmJson.type === "package";
+
+  // if we were given file globs, we don't need to check the tests/ directory exists
+  // this is only for elm applications, which people may need to introduce slowly into their apps
+  // for packages, we stick with the existing behaviour and assume tests are in tests/
+  if (hasBeenGivenCustomGlobs === false && isPackageProject === false) {
     if (!fs.existsSync(testRootDir)) {
       console.error("Error: " + testRootDir + " does not exist. Please create a tests/ directory in your project root!");
       process.exit(1);
@@ -74,16 +86,6 @@ function generateElmJson(projectRootDir/*:string*/, testRootDir/*:string*/, path
 
   fs.mkdirpSync(generatedCodeDir);
   fs.mkdirpSync(generatedSrc);
-
-  var projectElmJson = {};
-
-  try {
-    projectElmJson = fs.readJsonSync(elmJsonPath);
-  } catch (err) {
-    console.error("Error reading elm.json: " + err);
-    process.exit(1);
-  }
-  var isPackageProject = projectElmJson.type === "package";
 
   var testElmJson = {
     type: "application",

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -302,7 +302,7 @@ if (args._[0] === "make") {
         ? 'No tests found for the file pattern "' +
           fileGlobs.toString() +
           '"\n\nMaybe try running elm-test with no arguments?'
-        : "No tests found in the tests/ directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm.json lives.\n\nTo generate some initial tests to get things going, run elm-test init";
+        : "No tests found in the tests/ directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm.json lives.\n\nTo generate some initial tests to get things going, run elm-test init.\n\nAlternatively, if you have tests in a different directory, try calling elm-test with a glob: elm-test 'frontend-app/**/*Tests.elm'.";
 
     console.error(errorMessage);
     process.exit(1);

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -281,7 +281,7 @@ if (args._[0] === "make") {
   const testFilePaths = resolveGlobs(files);
   const projectRootDir = getProjectRootDir(testFilePaths);
   const testRootDir = getTestRootDir(projectRootDir);
-  const generatedCodeDir = Generate.generateElmJson(projectRootDir, testRootDir, pathToElmBinary, testFilePaths)[0];
+  const generatedCodeDir = Generate.generateElmJson(projectRootDir, testRootDir, pathToElmBinary, testFilePaths, fileGlobs.length > 0)[0];
 
   Compile.compileAll(testFilePaths, generatedCodeDir, args.verbose, pathToElmBinary, args.report).then(function() {
     process.exit(0);
@@ -310,7 +310,7 @@ if (args._[0] === "make") {
 
   const projectRootDir = getProjectRootDir(testFilePaths);
   const testRootDir = getTestRootDir(projectRootDir);
-  const returnValues = Generate.generateElmJson(projectRootDir, testRootDir, pathToElmBinary, testFilePaths);
+  const returnValues = Generate.generateElmJson(projectRootDir, testRootDir, pathToElmBinary, testFilePaths, fileGlobs.length > 0);
   const generatedCodeDir = returnValues[0];
   const generatedSrc = returnValues[1];
   const sourceDirs = returnValues[2];

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -302,7 +302,7 @@ if (args._[0] === "make") {
         ? 'No tests found for the file pattern "' +
           fileGlobs.toString() +
           '"\n\nMaybe try running elm-test with no arguments?'
-        : "No tests found in the tests/ directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm.json lives.\n\nTo generate some initial tests to get things going, run elm-test init.\n\nAlternatively, if you have tests in a different directory, try calling elm-test with a glob: elm-test 'frontend-app/**/*Tests.elm'.";
+        : "No tests found in the tests/ directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm.json lives.\n\nTo generate some initial tests to get things going, run elm-test init.\n\nAlternatively, if your application has tests in a different directory, try calling elm-test with a glob: elm-test 'frontend-app/**/*Tests.elm'.";
 
     console.error(errorMessage);
     process.exit(1);

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -295,20 +295,34 @@ if (args._[0] === "make") {
   // Ergo, globify all the arguments we receive.
   const fileGlobs = args._.length > 0 ? args._ : [];
   const testFilePaths = resolveGlobs(fileGlobs);
+  const projectRootDir = getProjectRootDir(testFilePaths);
+
+  const elmJsonPath = path.resolve(path.join(projectRootDir, "elm.json"));
+  var projectElmJson = {};
+
+  try {
+    projectElmJson = fs.readJsonSync(elmJsonPath);
+  } catch (err) {
+    console.error("Error reading elm.json: " + err);
+    process.exit(1);
+  }
+
+  var isPackageProject = projectElmJson.type === "package";
 
   if (testFilePaths.length === 0) {
+    var extraAppError = "\n\nAlternatively, if your application has tests in a different directory, try calling elm-test with a glob: elm-test 'frontend-app/**/*Tests.elm'.";
+
     var errorMessage =
       fileGlobs.length > 0
         ? 'No tests found for the file pattern "' +
           fileGlobs.toString() +
           '"\n\nMaybe try running elm-test with no arguments?'
-        : "No tests found in the tests/ directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm.json lives.\n\nTo generate some initial tests to get things going, run elm-test init.\n\nAlternatively, if your application has tests in a different directory, try calling elm-test with a glob: elm-test 'frontend-app/**/*Tests.elm'.";
+        : "No tests found in the tests/ directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm.json lives.\n\nTo generate some initial tests to get things going, run elm-test init." + (isPackageProject ? '' : extraAppError);
 
     console.error(errorMessage);
     process.exit(1);
   }
 
-  const projectRootDir = getProjectRootDir(testFilePaths);
   const testRootDir = getTestRootDir(projectRootDir);
   const returnValues = Generate.generateElmJson(projectRootDir, testRootDir, pathToElmBinary, testFilePaths, fileGlobs.length > 0);
   const generatedCodeDir = returnValues[0];


### PR DESCRIPTION
We run our tests via `elm-test 'frontend/**/*Tests.elm'` as our app is a
big monorepo and we don't want our Elm tests in the top level `tests`
directory.

However, doing this gives us an error that the `tests/` folder doesn't
exist. I updated the code to only check for and use `tests/` if not
given a glob.

@rtfeldman let me know what you think!