### PR TITLE
Use cross-spawn to run elm-test in tests

### DIFF
--- a/tests/flags.js
+++ b/tests/flags.js
@@ -14,24 +14,9 @@ const stripAnsi = require("strip-ansi");
 // Automatically track and cleanup files at exit
 temp.track();
 
+const elmTestPath = path.join(__dirname, "..", "bin", "elm-test");
 const elmHome = path.join(__dirname, "..", "fixtures", "elm-home");
 const spawnOpts = { silent: true, env: Object.assign({ELM_HOME: elmHome}, process.env)};
-let elmTestPath = path.join(__dirname, "..", "bin", "elm-test");
-
-if(!fs.existsSync(elmTestPath)) {
-  throw new Error("Could not find elm-test binary at:", elmTestPath);
-}
-
-// On Windows, use the locally-installed binary because
-// trying to execute bin/elm-test with an absolute path
-// doesn't work.
-//
-// TODO: can we find a way to do that? This way has the
-//       downside of making it so you have to `npm install`
-//       before these tests will work properly on Windows.
-if (process.platform === "win32") {
-  elmTestPath = "elm-test";
-}
 
 function elmTestWithYes(args, callback) {
   const child = spawn(elmTestPath, args, spawnOpts);
@@ -45,7 +30,7 @@ function elmTestWithYes(args, callback) {
 }
 
 function execElmTest(args) {
-  return shell.exec([elmTestPath].concat(args).join(" "), spawnOpts);
+  return spawn.sync(elmTestPath, args, Object.assign({encoding: "utf-8"}, spawnOpts));
 }
 
 describe("flags", () => {


### PR DESCRIPTION
@rtfeldman We can use `cross-spawn` instead of the workaround introduced in https://github.com/rtfeldman/node-test-runner/commit/d9937704f61657329cf5addbc679f95d374322d0

This also solved the hanging (#311) for some reason at least for Node 10.
![image](https://user-images.githubusercontent.com/639336/47590629-be05cf00-d921-11e8-9b6c-69ec33d3ee00.png)

https://ci.appveyor.com/project/kazk/node-test-runner/builds/19833641