### PR TITLE
Fix bug adding tests/ to source-directories

### DIFF
--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -81,7 +81,18 @@ function generateElmJson(
   // if we were given file globs, we don't need to check the tests/ directory exists
   // this is only for elm applications, which people may need to introduce slowly into their apps
   // for packages, we stick with the existing behaviour and assume tests are in tests/ so do the check always
-  if (hasBeenGivenCustomGlobs === false || isPackageProject === true) {
+  const needToCareAboutTestsDir =
+    hasBeenGivenCustomGlobs === false || isPackageProject === true;
+
+  // we add the tests dir as a source if:
+  // - we decided above we need to care about it
+  // - if it exists on disk: this supports the case where we have all our tests in tests/ but
+  //   want to pass a glob to only run one of the test files
+  const shouldAddTestsDirAsSource =
+    needToCareAboutTestsDir ||
+    fs.existsSync(path.join(projectRootDir, 'tests'));
+
+  if (needToCareAboutTestsDir) {
     if (!fs.existsSync(testRootDir)) {
       console.error(
         'Error: ' +
@@ -191,7 +202,7 @@ function generateElmJson(
     .map(function(src) {
       return path.resolve(path.join(projectRootDir, src));
     })
-    .concat([testRootDir]);
+    .concat(shouldAddTestsDirAsSource ? [testRootDir] : []);
 
   testElmJson['source-directories'] = [
     // Include elm-stuff/generated-sources - since we'll be generating sources in there.


### PR DESCRIPTION
This bug meant that running `elm-test "/not/default/path/*.elm"` would
error if `tests/` directory didn't exist, because we'd add it to the
`source-directories` of the new `elm.json` file we create.

This fix now ensures we only add the `source-directories` if:

- we're a package, and therefore using `tests/` for our tests
- we're called without a glob, and therefore are defaulting to `tests/`
- the `tests/` folder exists on disk. This covers the case where I call
`elm-test "tests/Foo.elm"` to only run one file.

If none of the above is true, we don't default to adding the `tests`
directory.

This is a small bug with the implementation of #306