### PR TITLE
Add FileList to polyfills

### DIFF
--- a/templates/before.js
+++ b/templates/before.js
@@ -20,6 +20,10 @@ var location = {
 };
 var document = { body: {}, createTextNode: function() {}, location: location };
 
+if (typeof FileList === "undefined") {
+    FileList = function() {};
+}
+
 if (typeof XMLHttpRequest === "undefined") {
   XMLHttpRequest = function() {
     return {


### PR DESCRIPTION
https://github.com/elm/json/blob/84ecbaa/src/Elm/Kernel/Json.js#L331 can cause an unhelpful decoding failure message if an array fails to decode, since Node doesn't have `FileList` natively in scope.

This polyfills it!