### PR TITLE
Remove node 6 from CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 language: node_js
 node_js:
-    - "6"
     - "8"
     - "10"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
   matrix:
   - nodejs_version: "10"
   - nodejs_version: "8"
-  - nodejs_version: "6"
 
 platform:
   # - x86


### PR DESCRIPTION
I'm not sure if this should be merged or not,  but CI is currently failing because of 

```
> elm-test@0.19.0-rev3 prettier:check /Users/travis/build/rtfeldman/node-test-runner
> prettier "lib/**/*.js" --list-different
lib/finder.js
npm ERR! Darwin 17.4.0
npm ERR! argv "/Users/travis/.nvm/versions/node/v6.14.4/bin/node" "/Users/travis/.nvm/versions/node/v6.14.4/bin/npm" "run" "prettier:check"
npm ERR! node v6.14.4
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! elm-test@0.19.0-rev3 prettier:check: `prettier "lib/**/*.js" --list-different`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the elm-test@0.19.0-rev3 prettier:check script 'prettier "lib/**/*.js" --list-different'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the elm-test package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     prettier "lib/**/*.js" --list-different
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs elm-test
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls elm-test
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /Users/travis/build/rtfeldman/node-test-runner/npm-debug.log
npm ERR! Test failed.  See above for more details.
The command "npm test" exited with 1.
```

it looks like maybe `prettier` no longer supports node 6?  The Mac, Linux, and Windows CI builds are all failing for node 6, but pass for other node versions.