### PR TITLE
Change elm-package.json -> elm.json in .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,6 @@
 [ignore]
 
-.*elm-package.json
+.*elm.json
 
 [include]
 


### PR DESCRIPTION
This must be hanging around from elm 18.

Although maybe `elm.json` does not need to be ignored?
It has not been ignored previously.