### PR TITLE
prevent command injection in elm-test install

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -8,6 +8,7 @@ var Compile = require('./Compile.js');
 var Generate = require('./Generate.js');
 var dns = require('dns');
 var processTitle = 'elm-test';
+var which = require('which');
 
 process.title = processTitle;
 
@@ -92,13 +93,22 @@ function resolveFilePath(filename) {
 let pathToElmBinary;
 
 if (args.compiler === undefined) {
-  pathToElmBinary = 'elm';
-} else {
-  pathToElmBinary = path.resolve(args.compiler);
-
-  if (!pathToElmBinary) {
+  try {
+    pathToElmBinary = which.sync('elm');
+  } catch (error) {
     console.error(
-      'The --compiler option must be given a path to an elm-make executable.'
+      `Cannot find elm executable, make sure it is installed.
+(If elm is not on your path or is called something different the --compiler flag might help.)`
+    );
+    console.error(error);
+    process.exit(1);
+  }
+} else {
+  try {
+    pathToElmBinary = which.sync(path.resolve(args.compiler));
+  } catch (error) {
+    console.error(
+      'The --compiler option must be given a path to an elm executable.'
     );
     process.exit(1);
   }

--- a/lib/install.js
+++ b/lib/install.js
@@ -51,9 +51,10 @@ function install(pathToElmBinary /*:string*/, packageName /*:string*/) {
 
     fs.writeFileSync(tmpElmJsonPath, JSON.stringify(elmJson), 'utf8');
 
-    var cmd = [pathToElmBinary, 'install'].concat([packageName]).join(' ');
-
-    child_process.execSync(cmd, { stdio: 'inherit', cwd: dirPath });
+    child_process.execFileSync(pathToElmBinary, ['install', packageName], {
+      stdio: 'inherit',
+      cwd: dirPath,
+    });
 
     var newElmJson = JSON.parse(fs.readFileSync(tmpElmJsonPath, 'utf8'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,7 +245,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "split": "1.0.1",
     "supports-color": "4.2.0",
     "temp": "0.8.3",
+    "which": "1.3.1",
     "xmlbuilder": "^8.2.2"
   },
   "optionalDependencies": {

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -98,6 +98,7 @@ describe("flags", () => {
 
     afterEach(() => {
       shell.popd();
+      shell.rm("-f", "elm.json");
     });
 
     it("should fail if the current directory does not contain an elm.json", () => {
@@ -108,6 +109,18 @@ describe("flags", () => {
 
       assert.notEqual(runResult.code, 0);
     });
+
+    it.only("should not allow command injection", () => {
+      shell.cp(path.join(__dirname, "templates", "application", "elm.json"), "elm.json");
+      const runResult = spawn.sync(
+        elmTestPath,
+        ["install", "elm/regex; printf 'FINDME'; printf 'TWICE'"],
+        Object.assign({ encoding: "utf-8", input: 'y\n' }, spawnOpts),
+      );
+      console.log(runResult);
+      assert(!runResult.stdout.includes('FINDME'));
+      assert(!runResult.stderr.includes('FINDMETWICE'));
+    }).timeout(60000);
   });
 
   describe("--help", () => {


### PR DESCRIPTION
`which` is used to get the path to the elm executable which allows
using `execFileSync` instead of `execSync` preventing any escape
characters included in the path to the elm compiler from being
evaluated by the shell.

I cannot think of anyway this could be exploited in its current state
but passing unsanitized user input to `execSync` is advised against.

See: https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options