### PR TITLE
Remove only in test suite

### DIFF
--- a/tests/flags.js
+++ b/tests/flags.js
@@ -130,7 +130,7 @@ describe('flags', () => {
       assert.notEqual(runResult.code, 0);
     });
 
-    it.only('should not allow command injection', () => {
+    it('should not allow command injection', () => {
       shell.cp(
         path.join(__dirname, 'templates', 'application', 'elm.json'),
         'elm.json'

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -78,7 +78,7 @@ describe('flags', () => {
 
           done();
         });
-      });
+      }).timeout(60000);
     });
 
     describe('for an APPLICATION', () => {
@@ -109,7 +109,7 @@ describe('flags', () => {
 
           done();
         });
-      });
+      }).timeout(60000);
     });
   });
   describe('elm-test install', () => {
@@ -128,7 +128,7 @@ describe('flags', () => {
       const runResult = execElmTest(['install', 'elm/regex']);
 
       assert.notEqual(runResult.code, 0);
-    });
+    }).timeout(60000);
 
     it('should not allow command injection', () => {
       shell.cp(
@@ -151,12 +151,12 @@ describe('flags', () => {
       // Checking against a fixture is brittle here
       // For now, check that the output is non-empty.
       assert.ok(runResult.stdout.length > 0);
-    });
+    }).timeout(60000);
 
     it('Should exit indicating failure', () => {
       const runResult = execElmTest(['--help']);
       assert.notEqual(0, runResult.code);
-    });
+    }).timeout(60000);
   });
 
   describe('--report', () => {


### PR DESCRIPTION
I added this `.only` when implementing https://github.com/rtfeldman/node-test-runner/pull/330, sorry!

The full test suite hasn't been running for a while.
It is a very good thing that elm-test gives a non zero exit code when `only` is used to prevent issues like this.

The test suite now fails, will follow up with a commit to fix this.