### PR TITLE
Allow test to run for longer

### DIFF
--- a/tests/flags.js
+++ b/tests/flags.js
@@ -289,6 +289,6 @@ describe('flags', () => {
           console.warn('Unexpected non-json output: ' + line);
         }
       });
-    }).timeout(60000);
+    }).timeout(100000);
   });
 });


### PR DESCRIPTION
This should stop appveyor ci from failing.

Refs: https://ci.appveyor.com/project/rtfeldman/node-test-runner/branch/master/job/tdt1wtlooqxp0cx5