### PR TITLE
Fix broken file watch on windows

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -258,21 +258,16 @@ function resolveGlobs(fileGlobs) {
   return _.flatMap(globs, resolveFilePath);
 }
 
-function getWatchPaths(projectRootDir /*:string*/) {
-  var watchedSourcePaths;
-  var elmJson = fs.readJsonSync(path.join(projectRootDir, 'elm.json'), 'utf8');
+function getWatchPaths(elmJson) {
+  let watchedSourcePaths;
   if (elmJson['type'] === 'package') {
-    watchedSourcePaths = ['./src'];
+    watchedSourcePaths = ['src'];
   } else {
     watchedSourcePaths = elmJson['source-directories'];
   }
-  var watchedTestPaths = path.join(projectRootDir, 'tests');
-  var watchedPaths = watchedSourcePaths
-    .concat(watchedTestPaths)
-    .map(function(sourcePath) {
-      return path.resolve(projectRootDir, sourcePath) + '/**/*.elm';
-    });
-  return watchedPaths;
+  return [...watchedSourcePaths, 'tests'].map(function(sourcePath) {
+    return path.posix.join(sourcePath, '**', '*.elm');
+  });
 }
 
 var report;
@@ -447,13 +442,14 @@ if (args._[0] === 'make') {
     clearConsole();
     infoLog('Running in watch mode');
 
-    var watchedPaths = getWatchPaths(projectRootDir);
+    var watchedPaths = getWatchPaths(projectElmJson);
     var watcher = chokidar.watch(watchedPaths, {
       awaitWriteFinish: {
         stabilityThreshold: 500,
       },
       ignoreInitial: true,
       ignored: /(\/|^)elm-stuff(\/|$)/,
+      cwd: projectRootDir,
     });
 
     var eventNameMap = {
@@ -468,7 +464,7 @@ if (args._[0] === 'make') {
       var relativePath = path.relative(testRootDir, filePath);
       var eventName = eventNameMap[event] || event;
       clearConsole();
-      infoLog('\n' + relativePath + ' ' + eventName + '. Rebuilding!');
+      infoLog('\n' + filePath + ' ' + eventName + '. Rebuilding!');
 
       // TODO if a previous run is in progress, wait until it's done.
       currentRun = currentRun.then(run);

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -258,15 +258,15 @@ function resolveGlobs(fileGlobs) {
   return _.flatMap(globs, resolveFilePath);
 }
 
-function getWatchPaths(elmJson) {
-  let watchedSourcePaths;
+function getGlobsToWatch(elmJson) {
+  let sourceDirectories;
   if (elmJson['type'] === 'package') {
-    watchedSourcePaths = ['src'];
+    sourceDirectories = ['src'];
   } else {
-    watchedSourcePaths = elmJson['source-directories'];
+    sourceDirectories = elmJson['source-directories'];
   }
-  return [...watchedSourcePaths, 'tests'].map(function(sourcePath) {
-    return path.posix.join(sourcePath, '**', '*.elm');
+  return [...sourceDirectories, 'tests'].map(function(sourceDirectory) {
+    return path.posix.join(sourceDirectory, '**', '*.elm');
   });
 }
 
@@ -442,8 +442,8 @@ if (args._[0] === 'make') {
     clearConsole();
     infoLog('Running in watch mode');
 
-    var watchedPaths = getWatchPaths(projectElmJson);
-    var watcher = chokidar.watch(watchedPaths, {
+    var globsToWatch = getGlobsToWatch(projectElmJson);
+    var watcher = chokidar.watch(globsToWatch, {
       awaitWriteFinish: {
         stabilityThreshold: 500,
       },

--- a/lib/finder.js
+++ b/lib/finder.js
@@ -38,7 +38,7 @@ function readExposing(filePath) {
 }
 
 /* Remove all the comments from the line, and return whether we are still in a multiline comment or not
-*/
+ */
 var stripComments = function(line, isInComment) {
   while (true || line.length > 0) {
     var startIndex = line.indexOf('{-');


### PR DESCRIPTION
Fix regression added in 2049ed5 where chokidar@2 silently
fails to watch globs when windows path seperators are present.

Fixes: https://github.com/rtfeldman/node-test-runner/issues/348
Refs: 2049ed5
Refs: https://github.com/paulmillr/chokidar/blob/master/CHANGELOG.md#chokidar-200-dec-29-2017