### PR TITLE
Fix elm test when source package has no dependancy on elm/core

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -44,6 +44,7 @@ example-application/
 example-application-no-tests/
 example-package/
 example-package-no-tests/
+example-package-no-core/
 
 README.md
 CHANGELOG.md

--- a/elm/elm.json
+++ b/elm/elm.json
@@ -6,8 +6,8 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.0",
-            "elm/json": "1.0.0",
+            "elm/core": "1.0.2",
+            "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0"
         },

--- a/example-package-no-core/.gitignore
+++ b/example-package-no-core/.gitignore
@@ -1,0 +1,1 @@
+/elm-stuff

--- a/example-package-no-core/elm.json
+++ b/example-package-no-core/elm.json
@@ -1,0 +1,13 @@
+{
+  "type": "package",
+  "name": "example ",
+  "summary": "SSCCE on replicating issue 273",
+  "version": "4.0.1",
+  "elm-version": "0.19.0 <= v < 0.20.0",
+  "dependencies": {
+    "elm/http": "2.0.0 <= v < 3.0.0"
+  },
+  "test-dependencies": {
+    "elm-explorations/test": "1.2.1 <= v < 2.0.0"
+  }
+}

--- a/example-package-no-core/tests/Example.elm
+++ b/example-package-no-core/tests/Example.elm
@@ -1,0 +1,10 @@
+module Example exposing (..)
+
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    test "placeholder" (\_ -> Expect.pass)

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -115,6 +115,8 @@ if (interfaceExitCode !== 0) {
 shell.echo(filename + ': Verifying installed elm-test version...');
 run('--version');
 
+/* Test examples */
+
 shell.echo('### Testing elm-test on example-application/');
 
 shell.cd('example-application');
@@ -134,6 +136,24 @@ assertTestFailure(path.join('tests', '*Fail*.elm'));
 assertTestFailure();
 
 shell.cd('../');
+
+shell.echo('### Testing elm-test on example-application-no-tests');
+
+shell.cd('example-application-no-tests');
+
+assertTestFailure();
+
+shell.cd('../');
+
+shell.echo('### Testing elm-test on example-package-no-core');
+
+shell.cd('example-package-no-core');
+
+assertTestSuccess();
+
+shell.cd('../');
+
+/* ci tests on single elm files */
 
 shell.ls('tests/*.elm').forEach(function(testToRun) {
   if (/Passing\.elm$/.test(testToRun)) {


### PR DESCRIPTION
These commits:

* Update the test runner's elm dependencies to fix @Maxim-Filimonov SSCCE.
* Add the sscce as a test.

---

Note that this does not fix the underlying issue of invalid dependencies giving an unhelpful error.

Refs: #273