### PR TITLE
Clarify configuration section by renaming header

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ elm-test                 # Run all exposed Test values in *.elm files in tests/
 elm-test Foo.elm         # Run all exposed Test values in Foo.elm
 ```
 
-### Configuration
+### Comand Line Arguments
 
 #### `install`
 


### PR DESCRIPTION
This section describes the command line arguments to elm-test rather than configuration.
Some of the arguments (say `--seed`)  _do_ configure the test runner but others (such as help) do not.