### PR TITLE
upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,6 +1206,11 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.2.0.tgz",
           "integrity": "sha1-yfSIbn9/vwr8EtcZQdzgaxkq6gU="
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         }
       }
     },
@@ -1623,9 +1628,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -1851,6 +1856,13 @@
         "find-elm-dependencies": "2.0.1",
         "lodash": "4.17.11",
         "temp": "^0.8.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
       }
     },
     "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "firstline": "1.2.1",
     "fs-extra": "0.30.0",
     "glob": "7.1.1",
-    "lodash": "4.17.11",
+    "lodash": "^4.17.13",
     "minimist": "^1.2.0",
     "murmur-hash-js": "1.0.0",
     "node-elm-compiler": "5.0.3",


### PR DESCRIPTION
A security vulnerability is reported by GitHub.

> Vulnerable versions: < 4.17.13
> Patched version: 4.17.13
>
> Affected versions of lodash are vulnerable to Prototype Pollution.
> The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.