### PR TITLE
fix tests that check exit code of spawned elm test

### DIFF
--- a/tests/flags.js
+++ b/tests/flags.js
@@ -132,6 +132,7 @@ describe('flags', () => {
 
       const runResult = execElmTest(['install', 'elm/regex']);
 
+      assert.ok(Number.isInteger(runResult.status));
       assert.notEqual(runResult.status, 0);
     }).timeout(60000);
 
@@ -268,7 +269,8 @@ describe('flags', () => {
         path.join('tests', 'Passing', 'One.elm'),
       ]);
 
-      assert.notEqual(0, runResult.status);
+      assert.ok(Number.isInteger(runResult.status));
+      assert.notEqual(runResult.status, 0);
     }).timeout(5000); // This sometimes needs more time to run on Travis.
   });
 

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -132,7 +132,7 @@ describe('flags', () => {
 
       const runResult = execElmTest(['install', 'elm/regex']);
 
-      assert.notEqual(runResult.code, 0);
+      assert.notEqual(runResult.status, 0);
     }).timeout(60000);
 
     it('should not allow command injection', () => {
@@ -158,9 +158,9 @@ describe('flags', () => {
       assert.ok(runResult.stdout.length > 0);
     }).timeout(60000);
 
-    it('Should exit indicating failure', () => {
+    it('Should exit indicating success (see #359)', () => {
       const runResult = execElmTest(['--help']);
-      assert.notEqual(0, runResult.code);
+      assert.strictEqual(0, runResult.status);
     }).timeout(60000);
   });
 
@@ -268,7 +268,7 @@ describe('flags', () => {
         path.join('tests', 'Passing', 'One.elm'),
       ]);
 
-      assert.notEqual(0, runResult.code);
+      assert.notEqual(0, runResult.status);
     }).timeout(5000); // This sometimes needs more time to run on Travis.
   });
 


### PR DESCRIPTION
Currently, a few tests check the `code` property of spawned processes.
However, the cross-spawn library does not define a `code` property on
the objects it returns; instead it defines a `status` property!

The test runner's unit tests where checking that the `code` was not
zero. Of course the code was not zero: it was `undefined` :angry:

As well as fixing the unit tests to check `.status` instead of `.code`
this commit fixes a unit test checked (or more accurately _did not
check_) the exit code of `elm-test --help` in light of
https://github.com/rtfeldman/node-test-runner/issues/359.

A prime example of why static typing is a boon for programming languages.