### PR TITLE
Upgrade version of node-elm-compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -496,23 +496,18 @@
       }
     },
     "find-elm-dependencies": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.1.tgz",
-      "integrity": "sha512-KBxPjc7J1CLw90jVateMKvMYMROZRTR7/QT2I3MxT+7I6KuUQUMNUFuS/eQXQnMnyElGKQ1iyPbe7GnEuYnFXw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.2.tgz",
+      "integrity": "sha512-nM5UCbccD1G8CGK2GsM7ykG3ksOAl9E+34jiDfl07CAl2OPnLpBVWY2hlxEmIkSBfdJjSopEowWHrO0cI8RhxQ==",
       "requires": {
         "firstline": "1.2.0",
-        "lodash": "4.17.11"
+        "lodash": "4.17.15"
       },
       "dependencies": {
         "firstline": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.2.0.tgz",
           "integrity": "sha1-yfSIbn9/vwr8EtcZQdzgaxkq6gU="
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         }
       }
     },
@@ -921,15 +916,6 @@
         "chalk": "^2.0.1"
       }
     },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -972,7 +958,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1099,44 +1085,14 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-elm-compiler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.3.tgz",
-      "integrity": "sha512-I3CWm/ExYYQ/a9bjB0OL9VsGa3Lmgbb8QOs4y2kEiB/DTkTqkcTaCr/lVyOYjRpgR25TsmOBATscsg6H6aC9Hg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.4.tgz",
+      "integrity": "sha512-VQsT8QSierYGkHzRed+b4MnccQVF1+qPHunE8jBoU7jD6YpuRqCDPzEoC2zfyEJS80qVnlMZrqobLnyjzX9lJg==",
       "requires": {
-        "cross-spawn": "4.0.0",
-        "find-elm-dependencies": "2.0.1",
-        "lodash": "4.17.11",
-        "temp": "^0.8.3"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz",
-          "integrity": "sha1-glR3SrR4a4xbPPTfumbOVjkywlI=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        },
-        "temp": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-          "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-          "requires": {
-            "os-tmpdir": "^1.0.0",
-            "rimraf": "~2.2.6"
-          }
-        }
+        "cross-spawn": "6.0.5",
+        "find-elm-dependencies": "2.0.2",
+        "lodash": "4.17.15",
+        "temp": "^0.9.0"
       }
     },
     "node-environment-flags": {
@@ -1221,11 +1177,6 @@
         "mem": "^4.0.0"
       }
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -1305,11 +1256,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
       "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.31",
@@ -1791,11 +1737,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "13.2.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "4.17.15",
     "minimist": "^1.2.0",
     "murmur-hash-js": "1.0.0",
-    "node-elm-compiler": "5.0.3",
+    "node-elm-compiler": "5.0.4",
     "split": "1.0.1",
     "supports-color": "7.0.0",
     "temp": "0.9.0",


### PR DESCRIPTION
`node-elm-compiler` recently got a new patch version to address a security vulnerability in `lodash`. This upgrades `node-test-runner` to use this new version, to address the security vulnerability here too.

Addresses #360