### PR TITLE
Run test suite twice due to flaky tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - npm install
 
 script:
-  - npm test
+  - npm test || npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,6 @@ install:
   - npm install
 
 test_script:
-  - npm test
+  - npm test -or npm test
 
 build: off


### PR DESCRIPTION
We have a couple of flaky tests e.g.

```
  1) flags
       --fuzz
         Should use the provided value:
     AssertionError [ERR_ASSERTION]: '5' == undefined
      at Context.<anonymous> (tests\flags.js:260:14)
      at processImmediate (internal/timers.js:439:21)
```

causing valid pull requests to go red.

This is a hack, and a nasty one at that but it will hopefully mean less CI runs need to be manually restarted. It would be good to find and fix the root cause too though