### PR TITLE
include debug info in assertion error

### DIFF
--- a/tests/flags.js
+++ b/tests/flags.js
@@ -234,7 +234,7 @@ describe('flags', () => {
       ]);
       const firstOutput = JSON.parse(runResult.stdout.split('\n')[0]);
 
-      assert.equal('12345', firstOutput.initialSeed);
+      assert.equal('12345', firstOutput.initialSeed, runResult.stdout);
     }).timeout(60000);
   });
 
@@ -246,7 +246,7 @@ describe('flags', () => {
       ]);
       const firstOutput = JSON.parse(runResult.stdout.split('\n')[0]);
 
-      assert.equal('100', firstOutput.fuzzRuns);
+      assert.equal('100', firstOutput.fuzzRuns, runResult.stdout);
     }).timeout(60000);
 
     it('Should use the provided value', () => {
@@ -257,7 +257,7 @@ describe('flags', () => {
       ]);
       const firstOutput = JSON.parse(runResult.stdout.split('\n')[0]);
 
-      assert.equal('5', firstOutput.fuzzRuns);
+      assert.equal('5', firstOutput.fuzzRuns, runResult.stdout);
     }).timeout(60000);
   });
 


### PR DESCRIPTION
For a flaky test that does not fail on my computer
but does (often) fail in CI print extra info
in the error message to help with debugging.

Should be reverted later (or never merged)