### PR TITLE
Do not fail fast for appveyor & retry failed on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - npm install
 
 script:
-  - npm test
+  - travis_retry npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@ environment:
 platform:
   - x64
 
-matrix:
-  fast_finish: true
-
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:Platform
   - node --version


### PR DESCRIPTION
Our tests are quite flaky right now and failing fast causes those flaky tests to propagate.