### PR TITLE
Bumps

### DIFF
--- a/elm/elm.json
+++ b/elm/elm.json
@@ -6,7 +6,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.2",
+            "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1683,9 +1683,9 @@
       }
     },
     "xmlbuilder": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
-      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ=="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
+      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -860,12 +860,12 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^2.4.2"
       },
       "dependencies": {
         "chalk": {
@@ -949,9 +949,9 @@
       }
     },
     "mocha": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.1.tgz",
-      "integrity": "sha512-9eWmWTdHLXh72rGrdZjNbG3aa1/3NRPpul1z0D979QpEnFdCG0Q5tv834N+94QEN2cysfV72YocQ3fn87s70fg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.0.tgz",
+      "integrity": "sha512-MymHK8UkU0K15Q/zX7uflZgVoRWiTjy0fXE/QjKts6mowUvGxOdPhZ2qj3b0iZdUrNZlW9LAIMFHB4IW+2b3EQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -965,7 +965,7 @@
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "3.13.1",
-        "log-symbols": "2.2.0",
+        "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "ms": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -532,9 +532,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.119.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.119.0.tgz",
-      "integrity": "sha512-fCVv++rjBsx/q6YVeB3F+A/owztjUO5PyBLwhGZdK5igVmiFQ8RKBTR9T2mb+SQRLZJJhl/xwPLhNzr3dBba6w==",
+      "version": "0.119.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.119.1.tgz",
+      "integrity": "sha512-mX6qjJVi7aLqR9sDf8QIHt8yYEWQbkMLw7qFoC7sM/AbJwvqFm3pATPN96thsaL9o1rrshvxJpSgoj1PJSC3KA==",
       "dev": true
     },
     "forever-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -532,9 +532,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.118.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.118.0.tgz",
-      "integrity": "sha512-jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==",
+      "version": "0.119.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.119.0.tgz",
+      "integrity": "sha512-fCVv++rjBsx/q6YVeB3F+A/owztjUO5PyBLwhGZdK5igVmiFQ8RKBTR9T2mb+SQRLZJJhl/xwPLhNzr3dBba6w==",
       "dev": true
     },
     "forever-agent": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "byline": "^5.0.0",
     "elm": "0.19.1-3",
     "elm-format": "0.8.2",
-    "flow-bin": "0.118.0",
+    "flow-bin": "0.119.0",
     "mocha": "7.0.1",
     "prettier": "^1.18.2",
     "shelljs": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "supports-color": "7.1.0",
     "temp": "0.9.1",
     "which": "2.0.2",
-    "xmlbuilder": "^13.0.2"
+    "xmlbuilder": "^14.0.0"
   },
   "optionalDependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "elm": "0.19.1-3",
     "elm-format": "0.8.2",
     "flow-bin": "0.119.1",
-    "mocha": "7.0.1",
+    "mocha": "7.1.0",
     "prettier": "^1.18.2",
     "shelljs": "0.8.3",
     "strip-ansi": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "byline": "^5.0.0",
     "elm": "0.19.1-3",
     "elm-format": "0.8.2",
-    "flow-bin": "0.119.0",
+    "flow-bin": "0.119.1",
     "mocha": "7.0.1",
     "prettier": "^1.18.2",
     "shelljs": "0.8.3",


### PR DESCRIPTION
The MAJOR change in xmlbuilder is to drop support for node 6. We no longer support node 6 so this is not a problem.

Otherwise we have minor changes to elm/core and flow-bin