### PR TITLE
only run prettier on lts node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ os:
   - linux
   - osx
 
-install:
-  - node --version
-  - npm --version
-  - npm install
-
 script:
-  - travis_retry npm test
+  - travis_retry npm run test-only
+
+
+jobs:
+  include:
+    - stage: other
+      script: npm run format:check
+      node_js: lts/*
+      name: Lint

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "flow": "flow",
-    "test": "flow check && npm run format:check && mocha tests && cd elm && node ../bin/elm-test",
+    "test-only": "mocha tests && cd elm && node ../bin/elm-test",
+    "test": "flow check && npm run format:check && npm run test-only",
     "format:check": "prettier \"lib/**/*.js\" \"tests/**/*.js\" --list-different --parser flow && elm-format elm --validate",
     "format:write": "prettier \"lib/**/*.js\" \"tests/**/*.js\" --parser flow --write && elm-format elm --yes"
   },


### PR DESCRIPTION
a) this means folk can see test failures and lint failures seperately
b) We can upgrade to prettier@2 which refuses to run on node 8 (boo).

(b) is more important here.