### PR TITLE
Separate paths with newlines

### DIFF
--- a/example-application-lots-of-files/.gitignore
+++ b/example-application-lots-of-files/.gitignore
@@ -1,0 +1,2 @@
+/elm-stuff
+/tests/TestsPassing*

--- a/example-application-lots-of-files/create_tests.sh
+++ b/example-application-lots-of-files/create_tests.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+
+set -euxo pipefail
+
+TEMPLATE=$(cat <<-EOS
+
+import Expect
+import Something
+import Test exposing (Test, test)
+
+
+testEqual : Test
+testEqual =
+    test "Expect.equal works" <|
+        \\() ->
+            Something.ultimateAnswer
+                |> Expect.equal 42
+EOS
+)
+
+rm -rf tests
+
+mkdir tests
+
+cd tests
+
+for x in `seq 1 2000`; do
+  echo "module TestsPassing${x} exposing (testEqual)" > "TestsPassing${x}.elm"
+  echo "$TEMPLATE" >> "TestsPassing${x}.elm"
+done

--- a/example-application-lots-of-files/elm.json
+++ b/example-application-lots-of-files/elm.json
@@ -1,0 +1,25 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.0",
+            "elm/json": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.0"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
+    }
+}

--- a/example-application-lots-of-files/src/Something.elm
+++ b/example-application-lots-of-files/src/Something.elm
@@ -1,0 +1,6 @@
+module Something exposing (ultimateAnswer)
+
+
+ultimateAnswer : Int
+ultimateAnswer =
+    42

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -396,7 +396,7 @@ function generateMainModule(
     fuzz: isNaN(fuzz) ? 'Nothing' : 'Just ' + fuzz,
     seed: seed,
     report: getReportCode(),
-    paths: testFilePaths.map(sanitizedToString).join(',\n      '),
+    paths: testFilePaths.map(sanitizedToString).join(','),
   };
 
   var optsCode =

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -396,7 +396,7 @@ function generateMainModule(
     fuzz: isNaN(fuzz) ? 'Nothing' : 'Just ' + fuzz,
     seed: seed,
     report: getReportCode(),
-    paths: testFilePaths.map(sanitizedToString).join(','),
+    paths: testFilePaths.map(sanitizedToString).join(',\n      '),
   };
 
   var optsCode =

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -142,39 +142,34 @@ if (versionRun.stdout.trim() !== elmTestVersion) {
 /* Test examples */
 
 shell.echo('### Testing elm-test on example-application/');
-
 shell.cd('example-application');
-
 assertTestFailure();
 assertTestSuccess(path.join('tests', '*Pass*.elm'), false);
 assertTestFailure(path.join('tests', '*Fail*.elm'));
-
 shell.cd('../');
 
 shell.echo('### Testing elm-test on example-package/');
-
 shell.cd('example-package');
-
 assertTestSuccess(path.join('tests', '*Pass*.elm'));
 assertTestFailure(path.join('tests', '*Fail*.elm'));
 assertTestFailure();
-
 shell.cd('../');
 
 shell.echo('### Testing elm-test on example-application-no-tests');
-
 shell.cd('example-application-no-tests');
-
 assertTestFailure();
-
 shell.cd('../');
 
 shell.echo('### Testing elm-test on example-package-no-core');
-
 shell.cd('example-package-no-core');
-
 assertTestSuccess();
+shell.cd('../');
 
+shell.echo('### Testing elm-test on example-application-lots-of-files/');
+shell.cd('example-application-lots-of-files');
+shell.echo('Creating a lot of tests..');
+shell.exec('./create_tests.sh');
+assertTestSuccess();
 shell.cd(fixturesDir);
 
 /* ci tests on single elm files */


### PR DESCRIPTION
Hi there! I noticed that when passing a very long list of files Elm 0.19.1 will blow up and report 

```
[2020-05-21T10:49:04.768Z] -- UNFINISHED LIST ----------------------- src/Test/Generated/Main2355714466.elm
[2020-05-21T10:49:04.768Z] 
[2020-05-21T10:49:04.768Z] I cannot find the end of this list:
```

Opening the file locally led me to discover that the incriminated line had around 74'000 characters. So in this PR I've separated each path with a newline, let me know if this seems the right approach!