### PR TITLE
Trim console reporter output (#431)

### DIFF
--- a/elm/src/Test/Reporter/Console.elm
+++ b/elm/src/Test/Reporter/Console.elm
@@ -92,8 +92,8 @@ textToValue useColor txt =
         |> Encode.string
 
 
-reportBegin : UseColor -> { paths : List String, fuzzRuns : Int, testCount : Int, initialSeed : Int } -> Maybe Value
-reportBegin useColor { paths, fuzzRuns, testCount, initialSeed } =
+reportBegin : UseColor -> { r | globs : List String, fuzzRuns : Int, testCount : Int, initialSeed : Int } -> Maybe Value
+reportBegin useColor { globs, fuzzRuns, testCount, initialSeed } =
     let
         prefix =
             "Running "
@@ -103,7 +103,7 @@ reportBegin useColor { paths, fuzzRuns, testCount, initialSeed } =
                 ++ " --seed "
                 ++ String.fromInt initialSeed
     in
-    (String.join " " (prefix :: paths) ++ "\n")
+    (String.join " " (prefix :: globs) ++ "\n")
         |> plain
         |> textToValue useColor
         |> Just

--- a/elm/src/Test/Reporter/JUnit.elm
+++ b/elm/src/Test/Reporter/JUnit.elm
@@ -5,7 +5,7 @@ import Test.Reporter.TestResults exposing (Failure, Outcome(..), SummaryInfo, Te
 import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
 
-reportBegin : { paths : List String, fuzzRuns : Int, testCount : Int, initialSeed : Int } -> Maybe Value
+reportBegin : runInfo -> Maybe Value
 reportBegin _ =
     Nothing
 

--- a/elm/src/Test/Reporter/Json.elm
+++ b/elm/src/Test/Reporter/Json.elm
@@ -5,12 +5,13 @@ import Test.Reporter.TestResults as TestResults exposing (Failure, Outcome(..), 
 import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
 
-reportBegin : { paths : List String, fuzzRuns : Int, testCount : Int, initialSeed : Int } -> Maybe Value
-reportBegin { paths, fuzzRuns, testCount, initialSeed } =
+reportBegin : { globs : List String, paths : List String, fuzzRuns : Int, testCount : Int, initialSeed : Int } -> Maybe Value
+reportBegin { globs, paths, fuzzRuns, testCount, initialSeed } =
     Encode.object
         [ ( "event", Encode.string "runStart" )
         , ( "testCount", Encode.string <| String.fromInt testCount )
         , ( "fuzzRuns", Encode.string <| String.fromInt fuzzRuns )
+        , ( "globs", Encode.list Encode.string globs )
         , ( "paths", Encode.list Encode.string paths )
         , ( "initialSeed", Encode.string <| String.fromInt initialSeed )
         ]

--- a/elm/src/Test/Reporter/Reporter.elm
+++ b/elm/src/Test/Reporter/Reporter.elm
@@ -23,7 +23,8 @@ type alias TestReporter =
 
 
 type alias RunInfo =
-    { paths : List String
+    { globs : List String
+    , paths : List String
     , fuzzRuns : Int
     , testCount : Int
     , initialSeed : Int

--- a/elm/src/Test/Runner/Node.elm
+++ b/elm/src/Test/Runner/Node.elm
@@ -37,6 +37,7 @@ type alias TestId =
 type alias InitArgs =
     { initialSeed : Int
     , processes : Int
+    , globs : List String
     , paths : List String
     , fuzzRuns : Int
     , runners : SeededRunners
@@ -48,6 +49,7 @@ type alias RunnerOptions =
     { seed : Int
     , runs : Maybe Int
     , report : Report
+    , globs : List String
     , paths : List String
     , processes : Int
     }
@@ -258,7 +260,7 @@ sendBegin model =
 
 
 init : InitArgs -> Int -> ( Model, Cmd Msg )
-init { processes, paths, fuzzRuns, initialSeed, report, runners } _ =
+init { processes, globs, paths, fuzzRuns, initialSeed, report, runners } _ =
     let
         { indexedRunners, autoFail } =
             case runners of
@@ -292,6 +294,7 @@ init { processes, paths, fuzzRuns, initialSeed, report, runners } _ =
             { available = Dict.fromList indexedRunners
             , runInfo =
                 { testCount = testCount
+                , globs = globs
                 , paths = paths
                 , fuzzRuns = fuzzRuns
                 , initialSeed = initialSeed
@@ -309,7 +312,7 @@ init { processes, paths, fuzzRuns, initialSeed, report, runners } _ =
 {-| Run the tests.
 -}
 run : RunnerOptions -> Test -> Program Int Model Msg
-run { runs, seed, report, paths, processes } test =
+run { runs, seed, report, globs, paths, processes } test =
     let
         fuzzRuns =
             Maybe.withDefault defaultRunCount runs
@@ -321,6 +324,7 @@ run { runs, seed, report, paths, processes } test =
             init
                 { initialSeed = seed
                 , processes = processes
+                , globs = globs
                 , paths = paths
                 , fuzzRuns = fuzzRuns
                 , runners = runners

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -284,6 +284,7 @@ function generateMainModule(
   fuzz /*: number */,
   seed /*: number */,
   report /*: string */,
+  testFileGlobs /*: Array<string> */,
   testFilePaths /*: Array<string> */,
   testModules /*: Array<{ moduleName: string, tests: Array<string> }> */,
   generatedSrc /*: string */,
@@ -350,6 +351,7 @@ function generateMainModule(
     fuzz: isNaN(fuzz) ? 'Nothing' : 'Just ' + fuzz,
     seed: seed,
     report: getReportCode(),
+    globs: testFileGlobs.map(sanitizedToString).join(','),
     paths: testFilePaths.map(sanitizedToString).join(','),
   };
 
@@ -362,7 +364,9 @@ function generateMainModule(
     opts.seed +
     ', processes = ' +
     processes +
-    ', paths = [' +
+    ', globs = [' +
+    opts.globs +
+    '], paths = [' +
     opts.paths +
     ']}';
 

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -367,7 +367,6 @@ if (args._[0] === 'make') {
   const testFileGlobs = args._.length > 0 ? args._ : [];
   const testFilePaths = resolveGlobs(testFileGlobs);
   const projectRootDir = getProjectRootDir(testFilePaths);
-  const hasBeenGivenCustomGlobs = fileGlobs.length > 0;
 
   const elmJsonPath = path.resolve(path.join(projectRootDir, 'elm.json'));
 
@@ -408,24 +407,25 @@ if (args._[0] === 'make') {
       Runner.getIndirectDeps(projectRootDir).then((packageIndirectDeps) => {
         return generateAndRun(
           projectRootDir,
+          testFileGlobs,
           testFilePaths,
-          packageIndirectDeps,
-          hasBeenGivenCustomGlobs
+          packageIndirectDeps
         );
       });
     });
   } else {
-    generateAndRun(projectRootDir, testFilePaths, {}, hasBeenGivenCustomGlobs);
+    generateAndRun(projectRootDir, testFileGlobs, testFilePaths, {});
   }
 }
 
 function generateAndRun(
   projectRootDir /*: string */,
+  testFileGlobs /* Array<string> */,
   testFilePaths /*: Array<string> */,
-  packageIndirectDeps /*: Object */,
-  hasBeenGivenCustomGlobs /*: boolean */
+  packageIndirectDeps /*: Object */
 ) {
   const generatedCodeDir = Compile.getGeneratedCodeDir(projectRootDir);
+  const hasBeenGivenCustomGlobs = testFileGlobs.length > 0;
 
   const returnValues = Generate.generateElmJson(
     projectRootDir,
@@ -457,6 +457,7 @@ function generateAndRun(
               parseInt(args.fuzz),
               parseInt(args.seed),
               args.report,
+              testFileGlobs,
               testFilePaths,
               testModules,
               generatedSrc,

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -364,8 +364,8 @@ if (args._[0] === 'make') {
   // On Bash 4.x (or zsh), if you give it a glob as its last argument, Bash
   // translates that into a list of file paths. On bash 3.x it's just a string.
   // Ergo, globify all the arguments we receive.
-  const fileGlobs = args._.length > 0 ? args._ : [];
-  const testFilePaths = resolveGlobs(fileGlobs);
+  const testFileGlobs = args._.length > 0 ? args._ : [];
+  const testFilePaths = resolveGlobs(testFileGlobs);
   const projectRootDir = getProjectRootDir(testFilePaths);
   const hasBeenGivenCustomGlobs = fileGlobs.length > 0;
 
@@ -385,9 +385,9 @@ if (args._[0] === 'make') {
       "\n\nAlternatively, if your application has tests in a different directory, try calling elm-test with a glob: elm-test 'frontend-app/**/*Tests.elm'.";
 
     var errorMessage =
-      fileGlobs.length > 0
+      testFileGlobs.length > 0
         ? 'No tests found for the file pattern "' +
-          fileGlobs.toString() +
+          testFileGlobs.toString() +
           '"\n\nMaybe try running elm-test with no arguments?'
         : "No tests found in the tests/ directory.\n\nNOTE: Make sure you're running elm-test from your project's root directory, where its elm.json lives.\n\nTo generate some initial tests to get things going, run elm-test init." +
           (isPackageProject ? '' : extraAppError);


### PR DESCRIPTION
Hello, this is my take on reducing the console output to a more manageable amount as discussed in #431 

Now it returns a short reproduction command like:
`Running 407 tests. To reproduce these results, run: elm-test --fuzz 100 --seed 115440003747078`
or
`Running 224 tests. To reproduce these results, run: elm-test --fuzz 100 --seed 41574277908519 tests\One.elm tests\Group\*`
instead of printing many many lines of absolute file paths.

---

I changed the data that is passed to all the reporters. I'm confident that it does not break anything for the console reporter, as it only printed the list of files before this commit, and now it prints the list of file globs passed to elm-test.

I'm not sure if it might break something for another tool that works with the output of the json reporter (e.g. if it needs the list of absolute paths of every found test file).

I would really appreciate if this (or a similar change) would make it into this nice tool.
