### PR TITLE
Increase timeout for two tests (fixes #449)

### DIFF
--- a/tests/flags.js
+++ b/tests/flags.js
@@ -288,7 +288,7 @@ describe('flags', () => {
         'elm-test',
         '--compiler=different-elm',
         path.join('tests', 'Passing', 'One.elm'),
-      ]);
+      ]).timeout(5000);
 
       assert.equal(runResult.status, 0);
     });

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -288,10 +288,10 @@ describe('flags', () => {
         'elm-test',
         '--compiler=different-elm',
         path.join('tests', 'Passing', 'One.elm'),
-      ]).timeout(5000);
+      ]);
 
       assert.equal(runResult.status, 0);
-    });
+    }).timeout(5000);
 
     it('Should work with local different elm', () => {
       const runResult = execElmTest([

--- a/tests/test-quality.js
+++ b/tests/test-quality.js
@@ -33,7 +33,7 @@ describe('examples quality', () => {
         if (require(path.join(example, 'elm.json')).type === 'package') {
           assert.strictEqual(execElm(['make'], example).status, 0);
         }
-      });
+      }).timeout(5000);
     }
   });
 });


### PR DESCRIPTION
Adds increased timeouts (5000 msec) to two tests that were failing on a semi-regular basis (at least for me)