### PR TITLE
Avoid recalculating dependencies if not needed

### DIFF
--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -174,7 +174,7 @@ function generateElmJson(
   }
 
   let testElmJson = Object.assign({}, testElmJsonTemplate, {
-    dependencies: Solve.get_dependencies(elmJsonPath, projectElmJson),
+    dependencies: Solve.get_dependencies(elmJsonPath),
     'test-dependencies': {
       direct: {},
       indirect: {},

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -60,7 +60,6 @@ function generateElmJson(
   const generatedSrc = path.join(generatedCodeDir, 'src');
 
   var isPackageProject = projectElmJson.type === 'package';
-  var dependencies = Solve.get_dependencies(elmJsonPath);
 
   // if we were given file globs, we don't need to check the tests/ directory exists
   // this is only for elm applications, which people may need to introduce slowly into their apps
@@ -99,31 +98,18 @@ function generateElmJson(
   fs.mkdirpSync(generatedCodeDir);
   fs.mkdirpSync(generatedSrc);
 
-  let testElmJson = {
-    type: 'application',
-    'source-directories': [], // these are added below
-    'elm-version': '0.19.1',
-    dependencies: dependencies,
-    'test-dependencies': {
-      direct: {},
-      indirect: {},
-    },
-  };
+  var projectSourceDirs = isPackageProject
+    ? ['./src']
+    : projectElmJson['source-directories'];
 
   // Make all the source-directories absolute, and introduce a new one.
-  var projectSourceDirs;
-  if (isPackageProject) {
-    projectSourceDirs = ['./src'];
-  } else {
-    projectSourceDirs = projectElmJson['source-directories'];
-  }
   var sourceDirs /*: Array<string> */ = projectSourceDirs
     .map(function (src) {
       return path.resolve(path.join(projectRootDir, src));
     })
     .concat(shouldAddTestsDirAsSource ? [testRootDir] : []);
 
-  testElmJson['source-directories'] = [
+  var allSourceDirs = [
     // Include elm-stuff/generated-sources - since we'll be generating sources in there.
     generatedSrc,
 
@@ -152,9 +138,51 @@ function generateElmJson(
       return path.relative(generatedCodeDir, absolutePath);
     });
 
+  // Everything is cheap to calculate except dependencies. Given the same input
+  // we should produce the same output. This function has many inputs but
+  // basically only one output – an elm.json. So the easiest way to compare
+  // inputs is to generate as much of elm.json as possible – all the cheap parts
+  // – and then just add the remaining inputs: dependencies from the project elm.json.
+  // This way we can compare this “template” between runs and avoid unneeded
+  // expensive work.
+  let testElmJsonTemplate = {
+    type: 'application',
+    'source-directories': allSourceDirs,
+    'elm-version': '0.19.1',
+    // All dependencies will be replaced with resolved ones below.
+    dependencies: projectElmJson.dependencies,
+    'test-dependencies': projectElmJson['test-dependencies'],
+  };
+
+  const generatedPath = path.join(generatedCodeDir, 'elm.json');
+  const templatePath = path.join(generatedCodeDir, 'elm.template.json');
+  const templateElmJsonString = JSON.stringify(testElmJsonTemplate, null, 4);
+
+  try {
+    if (
+      // If the elm.json we are creating already exists…
+      fs.existsSync(generatedPath) &&
+      // …and its template hasn’t changed…
+      fs.readFileSync(templatePath, 'utf8') === templateElmJsonString
+    ) {
+      // …then just return early and go with the generated elm.json we already have.
+      // This avoids calculating exact dependencies again and saves a second or so.
+      return [generatedCodeDir, generatedSrc, sourceDirs];
+    }
+  } catch (_error) {
+    // No template file since before, moving on.
+  }
+
+  let testElmJson = Object.assign({}, testElmJsonTemplate, {
+    dependencies: Solve.get_dependencies(elmJsonPath, projectElmJson),
+    'test-dependencies': {
+      direct: {},
+      indirect: {},
+    },
+  });
+
   // Generate the new elm.json, if necessary.
   const generatedContents = JSON.stringify(testElmJson, null, 4);
-  const generatedPath = path.join(generatedCodeDir, 'elm.json');
 
   // Don't write a fresh elm.json if it's going to be the same. If we do,
   // it will update the timestamp on the file, which will cause `elm make`
@@ -163,11 +191,11 @@ function generateElmJson(
     !fs.existsSync(generatedPath) ||
     generatedContents !== fs.readFileSync(generatedPath, 'utf8')
   ) {
-    // package projects don't explicitly list their transitive dependencies,
-    // to we have to figure out what they are.  We write the elm.json that
-    // we have so far, and run elm to see what it thinks is missing.
     fs.writeFileSync(generatedPath, generatedContents);
   }
+
+  // Write the template elm.json so we can find it the next time we build.
+  fs.writeFileSync(templatePath, templateElmJsonString);
 
   return [generatedCodeDir, generatedSrc, sourceDirs];
 }


### PR DESCRIPTION
Extracted from #442.

Running `elm-json solve` takes a second or so. But projects’ elm.json rarely change so we shouldn’t need to calculate dependencies every single time we run elm-test.

This PR creates an elm.template.json next to our generated elm.json which we can compare between runs to see if we need to solve dependencies again or not. See the code comments for more details.

I pretty consistently get 1 second faster test runs in various projects I try PR on.