### PR TITLE
Drop support for Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
   - '14'
+  - '15'
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 environment:
   ELM_VERSION: '0.19.1'
   matrix:
+    - nodejs_version: '15'
     - nodejs_version: '14'
     - nodejs_version: '12'
     - nodejs_version: '10'
-    - nodejs_version: '8'
 
 platform:
   - x64

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -42,14 +42,16 @@ var fs = require('fs-extra'),
   chokidar = require('chokidar'),
   Supervisor = require('./Supervisor.js');
 
-// Check Node version
+// Check Node.js version.
+const nodeVersionMin = '10.13.0';
 const nodeVersionString = process.versions.node;
-const nodeMajorVersion = Number(nodeVersionString.split('.')[0]);
 
-if (nodeMajorVersion < 8) {
-  console.log('using node v' + nodeVersionString);
+if (
+  nodeVersionString.localeCompare(nodeVersionMin, 'en', { numeric: true }) < 0
+) {
+  console.error(`You are using Node.js v${nodeVersionString}.`);
   console.error(
-    'elm-test requires node v8.0.0 or greater - upgrade the installed version of node and try again'
+    `elm-test requires Node.js v${nodeVersionMin} or greater - upgrade the installed version of Node.js and try again!`
   );
   process.exit(1);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,9 +2216,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "http://verdaccio.internal.utterberry.com/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.13.0"
   },
   "scripts": {
     "flow": "flow",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -4,18 +4,6 @@ const Runner = require('../lib/Runner.js');
 const assert = require('assert');
 const path = require('path');
 
-// TODO: remove this when we drop node 8 support
-function assertThrowsAsync(fn, regExp) {
-  return fn()
-    .then(
-      () => () => {},
-      (e) => () => {
-        throw e;
-      }
-    )
-    .then((f) => assert.throws(f, regExp));
-}
-
 describe('Runner', () => {
   describe('getFirstLine', () => {
     it('gets first line of this file', () =>
@@ -35,18 +23,18 @@ describe('Runner', () => {
 
     it('fails on an empty file', () => {
       const p = path.join(__dirname, 'fixtures', 'empty');
-      return assertThrowsAsync(
-        () => Runner.getFirstLine(p),
-        `File ${p} is empty`
-      );
+      return assert.rejects(() => Runner.getFirstLine(p), {
+        name: 'Error',
+        message: `File ${p} is empty!`,
+      });
     });
 
     it('fails a non existant file', () => {
       const p = path.join(__dirname, 'fixtures', 'must-never-exist');
-      return assertThrowsAsync(
-        () => Runner.getFirstLine(p),
-        `ENOENT: no such file or directory`
-      );
+      return assert.rejects(() => Runner.getFirstLine(p), {
+        name: 'Error',
+        message: `ENOENT: no such file or directory, open '${p}'`,
+      });
     });
   });
 });


### PR DESCRIPTION
This drops support for Node.js 8, bumping the minimum supported version to v10.13.0 (released 2018-10-30). I chose that particular version rather than v10.0.0 because:

- That’s the oldest version of the 10.x branch marked as LTS (see https://nodejs.org/en/download/releases/).
- This allows us to use `fs.mkdirSync(dir, { recursive: true })` (recursive was added in Node.js v10.12.0 – see https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options). This way Node.js has all we need to get rid of the `fs-extra` dependency.

I also added Node.js 15 to CI.

This is required by #442, which needs to use the “unicode property escapes” feature of regex which is supported only in Node.js 10+ (https://github.com/rtfeldman/node-test-runner/pull/442#discussion_r495579452).

The idea is that we should be able to release this as version 0.19.1-revision5. It’s technically a breaking change, but Node.js 8 has been end of life since 2019-12-31 and our versioning scheme doesn’t really have space for marking this as a breaking change. People who absolutely can’t upgrade Node.js can stay on an older version of node-test-runner until they’ve figured out an upgrade path.