### PR TITLE
Remove shelljs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,12 +1579,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-      "dev": true
-    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2204,12 +2198,6 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
-    "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -2293,15 +2281,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -2377,15 +2356,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "dev": true,
-      "requires": {
-        "path-parse": "^1.0.6"
-      }
-    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2459,17 +2429,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    },
-    "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2385,6 +2385,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -2665,6 +2666,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
       "integrity": "sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==",
+      "dev": true,
       "requires": {
         "rimraf": "~2.6.2"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "minimist": "^1.2.5",
     "murmur-hash-js": "^1.0.0",
     "split": "^1.0.1",
-    "temp": "^0.9.1",
     "which": "^2.0.2",
     "xmlbuilder": "^15.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "flow-bin": "0.135.0",
     "mocha": "7.2.0",
     "prettier": "2.1.2",
-    "shelljs": "0.8.4",
     "strip-ansi": "6.0.0",
     "xml2js": "0.4.23"
   }

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -17,13 +17,11 @@ const resultSuccess = 0;
 const resultErrored = 1;
 const resultFailureThreshold = 2;
 
-function execElmTest(args, cwd) {
-  // default: current directory
-  cwd = typeof cwd !== 'undefined' ? cwd : '.';
+function execElmTest(args, cwd = '.') {
   return spawn.sync(
     elmtestPath,
     args,
-    Object.assign({ encoding: 'utf-8', cwd: cwd }, spawnOpts)
+    Object.assign({ encoding: 'utf-8', cwd }, spawnOpts)
   );
 }
 

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -168,7 +168,6 @@ describe('flags', () => {
 
   describe('--report', () => {
     it('Should be able to report json lines', () => {
-      console.log('cwd', process.cwd());
       const runResult = execElmTest([
         '--report=json',
         path.join('tests', 'Passing', 'One.elm'),

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -66,16 +66,16 @@ describe('flags', () => {
         var json = JSON.parse(
           fs.readFileSync('elm.json', { encoding: 'utf-8' })
         );
-        assert.equal(
+        assert.strictEqual(
           typeof json['test-dependencies']['elm-explorations/test'],
           'undefined'
         );
 
         elmTestWithYes(['init'], (code) => {
-          assert.equal(code, 0);
+          assert.strictEqual(code, 0);
 
           json = JSON.parse(fs.readFileSync('elm.json', { encoding: 'utf-8' }));
-          assert.equal(
+          assert.strictEqual(
             typeof json['test-dependencies']['elm-explorations/test'],
             'string'
           );
@@ -97,16 +97,16 @@ describe('flags', () => {
         var json = JSON.parse(
           fs.readFileSync('elm.json', { encoding: 'utf-8' })
         );
-        assert.equal(
+        assert.strictEqual(
           typeof json['test-dependencies']['direct']['elm-explorations/test'],
           'undefined'
         );
 
         elmTestWithYes(['init'], (code) => {
-          assert.equal(code, 0);
+          assert.strictEqual(code, 0);
 
           json = JSON.parse(fs.readFileSync('elm.json', { encoding: 'utf-8' }));
-          assert.equal(
+          assert.strictEqual(
             typeof json['test-dependencies']['direct']['elm-explorations/test'],
             'string'
           );
@@ -116,6 +116,7 @@ describe('flags', () => {
       }).timeout(60000);
     });
   });
+
   describe('elm-test install', () => {
     beforeEach(() => {
       fs.ensureDirSync(scratchDir);
@@ -234,7 +235,7 @@ describe('flags', () => {
       ]);
       const firstOutput = JSON.parse(runResult.stdout.split('\n')[0]);
 
-      assert.equal('12345', firstOutput.initialSeed);
+      assert.strictEqual('12345', firstOutput.initialSeed);
     }).timeout(60000);
   });
 
@@ -246,7 +247,7 @@ describe('flags', () => {
       ]);
       const firstOutput = JSON.parse(runResult.stdout.split('\n')[0]);
 
-      assert.equal('100', firstOutput.fuzzRuns);
+      assert.strictEqual('100', firstOutput.fuzzRuns);
     }).timeout(60000);
 
     it('Should use the provided value', () => {
@@ -257,7 +258,7 @@ describe('flags', () => {
       ]);
       const firstOutput = JSON.parse(runResult.stdout.split('\n')[0]);
 
-      assert.equal('5', firstOutput.fuzzRuns);
+      assert.strictEqual('5', firstOutput.fuzzRuns);
     }).timeout(60000);
   });
 
@@ -289,7 +290,7 @@ describe('flags', () => {
         path.join('tests', 'Passing', 'One.elm'),
       ]);
 
-      assert.equal(runResult.status, 0);
+      assert.strictEqual(runResult.status, 0);
     }).timeout(5000);
 
     it('Should work with local different elm', () => {
@@ -299,7 +300,7 @@ describe('flags', () => {
         path.join('tests', 'Passing', 'One.elm'),
       ]);
 
-      assert.equal(runResult.status, 0);
+      assert.strictEqual(runResult.status, 0);
     }).timeout(5000);
   });
 


### PR DESCRIPTION
We don’t need shelljs in our tests – fs/fs-extra already has all we need, and we can use the `cwd` option when spawning processes.

(I intend to get rid of fs-extra throughout the entire code base in a future PR.)