### PR TITLE
Add more review rules 446

### DIFF
--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -24,13 +24,20 @@ import Review.Rule exposing (Rule)
 
 config : List Rule
 config =
-    [ {- NoUnused.CustomTypeConstructors.rule []
-              , NoUnused.Exports.rule
-              , NoUnused.Modules.rule
-         ,
-      -}
-      --  NoUnused.CustomTypeConstructorArgs.rule -- fails on Test/Runner/Diff.elm
-      NoUnused.Dependencies.rule
+    [ NoUnused.CustomTypeConstructors.rule []
+        |> Review.Rule.ignoreErrorsForFiles
+            [ "src/Test/Reporter/Reporter.elm" --ConsoleReport, JsonReport, JunitReport are used externally
+            , "src/Console/Text.elm" -- Monochrome, UseColor are used externally
+            ]
+
+    --, NoUnused.Exports.rule
+    , NoUnused.Modules.rule
+    , NoUnused.CustomTypeConstructorArgs.rule
+        |> Review.Rule.ignoreErrorsForFiles
+            [ "src/Test/Runner/Node/Vendor/Diff.elm" -- UnexpectedPath is used for reporting errors
+            , "src/Test/Runner/JsMessage.elm" -- Test is used for JSON decoding
+            ]
+    , NoUnused.Dependencies.rule
     , NoUnused.Parameters.rule
     , NoUnused.Patterns.rule
     , NoUnused.Variables.rule

--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -24,20 +24,14 @@ import Review.Rule exposing (Rule)
 
 config : List Rule
 config =
-    [ NoUnused.Variables.rule
+    [ {- NoUnused.CustomTypeConstructors.rule []
+              , NoUnused.Exports.rule
+              , NoUnused.Modules.rule
+         ,
+      -}
+      NoUnused.CustomTypeConstructorArgs.rule
+    , NoUnused.Dependencies.rule
+    , NoUnused.Parameters.rule
+    , NoUnused.Patterns.rule
+    , NoUnused.Variables.rule
     ]
-
-
-
-{-
-   config =
-       [ NoUnused.CustomTypeConstructors.rule []
-       , NoUnused.CustomTypeConstructorArgs.rule
-       , NoUnused.Dependencies.rule
-       , NoUnused.Exports.rule
-       , NoUnused.Modules.rule
-       , NoUnused.Parameters.rule
-       , NoUnused.Patterns.rule
-       , NoUnused.Variables.rule
-       ]
--}

--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -35,8 +35,7 @@ config =
             [ "src/Test/Runner/Node/Vendor/Diff.elm"
             , "src/Test/Runner/Node.elm"
             , "src/Test/Runner/Node/Vendor/Console.elm" 
-            , "src/Test/Reporter/TestResults.elm"
-            --, "src/Console/Text.elm"
+            --, "src/Test/Reporter/TestResults.elm" -- isTodo
             ]
     , NoUnused.Modules.rule
     , NoUnused.CustomTypeConstructorArgs.rule

--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -34,7 +34,7 @@ config =
         |> Review.Rule.ignoreErrorsForFiles
             [ "src/Test/Runner/Node/Vendor/Diff.elm"
             , "src/Test/Runner/Node.elm"
-            , "src/Test/Runner/Node/Vendor/Console.elm" 
+            --, "src/Test/Runner/Node/Vendor/Console.elm" 
             --, "src/Test/Reporter/TestResults.elm" -- isTodo
             ]
     , NoUnused.Modules.rule

--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -30,7 +30,14 @@ config =
             , "src/Console/Text.elm" -- Monochrome, UseColor are used externally
             ]
 
-    --, NoUnused.Exports.rule
+    , NoUnused.Exports.rule  
+        |> Review.Rule.ignoreErrorsForFiles
+            [ "src/Test/Runner/Node/Vendor/Diff.elm"
+            , "src/Test/Runner/Node.elm"
+            , "src/Test/Runner/Node/Vendor/Console.elm" 
+            , "src/Test/Reporter/TestResults.elm"
+            , "src/Console/Text.elm"
+            ]
     , NoUnused.Modules.rule
     , NoUnused.CustomTypeConstructorArgs.rule
         |> Review.Rule.ignoreErrorsForFiles

--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -29,8 +29,7 @@ config =
             [ "src/Test/Reporter/Reporter.elm" --ConsoleReport, JsonReport, JunitReport are used externally
             , "src/Console/Text.elm" -- Monochrome, UseColor are used externally
             ]
-
-    , NoUnused.Exports.rule  
+    , NoUnused.Exports.rule
         |> Review.Rule.ignoreErrorsForFiles
             [ "x" --"src/Test/Runner/Node/Vendor/Diff.elm"
             , "src/Test/Runner/Node.elm" -- run, TestProgram are used externally

--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -36,7 +36,7 @@ config =
             , "src/Test/Runner/Node.elm"
             , "src/Test/Runner/Node/Vendor/Console.elm" 
             , "src/Test/Reporter/TestResults.elm"
-            , "src/Console/Text.elm"
+            --, "src/Console/Text.elm"
             ]
     , NoUnused.Modules.rule
     , NoUnused.CustomTypeConstructorArgs.rule

--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -32,10 +32,8 @@ config =
 
     , NoUnused.Exports.rule  
         |> Review.Rule.ignoreErrorsForFiles
-            [ "src/Test/Runner/Node/Vendor/Diff.elm"
-            , "src/Test/Runner/Node.elm"
-            --, "src/Test/Runner/Node/Vendor/Console.elm" 
-            --, "src/Test/Reporter/TestResults.elm" -- isTodo
+            [ "x" --"src/Test/Runner/Node/Vendor/Diff.elm"
+            , "src/Test/Runner/Node.elm" -- run, TestProgram are used externally
             ]
     , NoUnused.Modules.rule
     , NoUnused.CustomTypeConstructorArgs.rule

--- a/elm/review/src/ReviewConfig.elm
+++ b/elm/review/src/ReviewConfig.elm
@@ -29,8 +29,8 @@ config =
               , NoUnused.Modules.rule
          ,
       -}
-      NoUnused.CustomTypeConstructorArgs.rule
-    , NoUnused.Dependencies.rule
+      --  NoUnused.CustomTypeConstructorArgs.rule -- fails on Test/Runner/Diff.elm
+      NoUnused.Dependencies.rule
     , NoUnused.Parameters.rule
     , NoUnused.Patterns.rule
     , NoUnused.Variables.rule

--- a/elm/src/Console/Text.elm
+++ b/elm/src/Console/Text.elm
@@ -4,21 +4,13 @@ module Console.Text exposing
     , Style
     , Text
     , UseColor(..)
-    , black
-    , blue
-    , bold
     , concat
-    , cyan
     , dark
-    , default
     , green
-    , inverted
-    , magenta
     , plain
     , red
     , render
     , underline
-    , white
     , yellow
     )
 

--- a/elm/src/Console/Text.elm
+++ b/elm/src/Console/Text.elm
@@ -82,13 +82,6 @@ plain =
 
 
 -- FOREGROUND COLORS --
-
-
-default : String -> Text
-default =
-    Text { foreground = Default, background = Default, style = Normal, modifiers = [] }
-
-
 red : String -> Text
 red =
     Text { foreground = Red, background = Default, style = Normal, modifiers = [] }
@@ -104,41 +97,6 @@ yellow =
     Text { foreground = Yellow, background = Default, style = Normal, modifiers = [] }
 
 
-black : String -> Text
-black =
-    Text { foreground = Black, background = Default, style = Normal, modifiers = [] }
-
-
-blue : String -> Text
-blue =
-    Text { foreground = Blue, background = Default, style = Normal, modifiers = [] }
-
-
-magenta : String -> Text
-magenta =
-    Text { foreground = Magenta, background = Default, style = Normal, modifiers = [] }
-
-
-cyan : String -> Text
-cyan =
-    Text { foreground = Cyan, background = Default, style = Normal, modifiers = [] }
-
-
-white : String -> Text
-white =
-    Text { foreground = White, background = Default, style = Normal, modifiers = [] }
-
-
-inverted : Text -> Text
-inverted txt =
-    case txt of
-        Text styles str ->
-            Text { styles | modifiers = Inverted :: styles.modifiers } str
-
-        Texts texts ->
-            Texts (List.map inverted texts)
-
-
 dark : Text -> Text
 dark txt =
     case txt of
@@ -151,16 +109,6 @@ dark txt =
 
 
 -- STYLES --
-
-
-bold : Text -> Text
-bold txt =
-    case txt of
-        Text styles str ->
-            Text { styles | style = Bold } str
-
-        Texts texts ->
-            Texts (List.map dark texts)
 
 
 underline : Text -> Text

--- a/elm/src/Console/Text.elm
+++ b/elm/src/Console/Text.elm
@@ -82,6 +82,8 @@ plain =
 
 
 -- FOREGROUND COLORS --
+
+
 red : String -> Text
 red =
     Text { foreground = Red, background = Default, style = Normal, modifiers = [] }

--- a/elm/src/Test/Reporter/Console.elm
+++ b/elm/src/Test/Reporter/Console.elm
@@ -151,7 +151,7 @@ reportSummary useColor { todos, passed, failed, duration } autoFail =
                 ( Just failure, 0, _ ) ->
                     Err ( yellow, "TEST RUN INCOMPLETE", " because " ++ failure )
 
-                ( _, _, _ ) ->
+                _ ->
                     Err ( red, "TEST RUN FAILED", "" )
 
         headline =

--- a/elm/src/Test/Reporter/Highlightable.elm
+++ b/elm/src/Test/Reporter/Highlightable.elm
@@ -1,4 +1,4 @@
-module Test.Reporter.Highlightable exposing (Highlightable, diffLists, fromDiff, map, resolve)
+module Test.Reporter.Highlightable exposing (Highlightable, diffLists, map, resolve)
 
 import Test.Runner.Node.Vendor.Diff as Diff exposing (Change(..))
 

--- a/elm/src/Test/Reporter/TestResults.elm
+++ b/elm/src/Test/Reporter/TestResults.elm
@@ -4,7 +4,6 @@ module Test.Reporter.TestResults exposing
     , SummaryInfo
     , TestResult
     , isFailure
-    , isTodo
     , outcomesFromExpectations
     )
 
@@ -40,16 +39,6 @@ type alias Failure =
     , description : String
     , reason : Reason
     }
-
-
-isTodo : Outcome -> Bool
-isTodo outcome =
-    case outcome of
-        Todo _ ->
-            True
-
-        _ ->
-            False
 
 
 isFailure : Outcome -> Bool

--- a/elm/src/Test/Runner/Node/Vendor/Console.elm
+++ b/elm/src/Test/Runner/Node/Vendor/Console.elm
@@ -1,4 +1,4 @@
-module Test.Runner.Node.Vendor.Console exposing (bgBlack, bgBlue, bgCyan, bgGreen, bgMagenta, bgRed, bgWhite, bgYellow, black, blue, bold, colorsInverted, cyan, dark, green, magenta, plain, red, underline, white, yellow)
+module Test.Runner.Node.Vendor.Console exposing (bgBlack, bgBlue, bgCyan, bgGreen, bgMagenta, bgRed, bgWhite, bgYellow, black, blue, bold, colorsInverted, cyan, dark, green, magenta, red, underline, white, yellow)
 
 {-| -}
 
@@ -42,12 +42,6 @@ module Test.Runner.Node.Vendor.Console exposing (bgBlack, bgBlue, bgCyan, bgGree
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 
-
-{-| Display the text in the console's default style.
--}
-plain : String -> String
-plain str =
-    String.join "" [ "\u{001B}[0m", str, "\u{001B}[0m" ]
 
 
 {-| Make the text darker.

--- a/elm/src/Test/Runner/Node/Vendor/Console.elm
+++ b/elm/src/Test/Runner/Node/Vendor/Console.elm
@@ -43,7 +43,6 @@ module Test.Runner.Node.Vendor.Console exposing (bgBlack, bgBlue, bgCyan, bgGree
 -}
 
 
-
 {-| Make the text darker.
 
 This can be used with other text modifiers, such as color.

--- a/elm/src/Test/Runner/Node/Vendor/Diff.elm
+++ b/elm/src/Test/Runner/Node/Vendor/Diff.elm
@@ -1,6 +1,6 @@
 module Test.Runner.Node.Vendor.Diff exposing
     ( Change(..)
-    , diff, diffLines
+    , diff
     )
 
 {-| Compares two list and returns how they have changed.
@@ -77,38 +77,6 @@ type BugReport
     = CannotGetA Int
     | CannotGetB Int
     | UnexpectedPath ( Int, Int ) (List ( Int, Int ))
-
-
-{-| Compares two text.
-
-Giving the following text
-
-    a =
-        """aaa
-    bbb
-    ddd"""
-
-    b =
-        """zzz
-    aaa
-    ccc
-    ddd"""
-
-results in
-
-    [ Added "zzz"
-    , NoChange "aaa"
-    , Removed "bbb"
-    , Added "ccc"
-    , NoChange "ddd"
-    ]
-
-.
-
--}
-diffLines : String -> String -> List (Change String)
-diffLines a b =
-    diff (String.lines a) (String.lines b)
 
 
 {-| Compares general lists.


### PR DESCRIPTION
Enables the remaining Unused review rules as discussed in #446. Things to note:
- a couple of files have been excluded because they're reported, but are essential for the executable to work properly (false positives, see discussion for #446)
- some minor changes to the copied external modules were necessary to make elm-review happy; if we decide to re-import them in the future, we'll need to re-apply these changes. This is not the optimal solution; we should probably either try to get the upstream modules to also use elm-review and clean up unused imports etc. or exclude them from elm-review.

Suggestions / feedback welcome :-)