### PR TITLE
Make port name conflicts less likely

### DIFF
--- a/templates/after.js
+++ b/templates/after.js
@@ -14,11 +14,11 @@ client.setNoDelay(true);
 var app = Elm.Test.Generated.Main.init({ flags: Date.now() });
 
 client.on('data', function (msg) {
-  app.ports.receive.send(JSON.parse(msg));
+  app.ports.elmTestPort__receive.send(JSON.parse(msg));
 });
 
 // Use ports for inter-process communication.
-app.ports.send.subscribe(function (msg) {
+app.ports.elmTestPort__send.subscribe(function (msg) {
   // We split incoming messages on the socket on newlines. The gist is that node
   // is rather unpredictable in whether or not a single `write` will result in a
   // single `on('data')` callback. Sometimes it does, sometimes multiple writes

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -159,6 +159,7 @@ describe('Testing elm-test on single Elm files', () => {
   const passingTestFiles = [
     'Dependency.elm',
     'One.elm',
+    'Ports.elm',
     'Several.elm',
     'TrickyMultilines.elm',
     'Unexposed.elm',

--- a/tests/fixtures/tests/Passing/Ports.elm
+++ b/tests/fixtures/tests/Passing/Ports.elm
@@ -1,0 +1,23 @@
+port module Passing.Ports exposing (..)
+
+import Expect
+import Test exposing (..)
+
+
+
+-- Reasonably common port names:
+
+
+port send : String -> Cmd msg
+
+
+port receive : (String -> msg) -> Sub msg
+
+
+testWithPorts : Test
+testWithPorts =
+    test "test with ports should pass" <|
+        \() ->
+            ( "success", ( send "out", receive always ) )
+                |> Tuple.first
+                |> Expect.equal "success"


### PR DESCRIPTION
If the project has `port send` or `port receive` in it (which are reasonably common port names), elm-test fails due to duplicate port errors – we also have ports named that way.

This PR prefixes the port names with `elmTestPort__` to reduce the likelihood of name conflicts.

This issue was reported on Slack.