### PR TITLE
Remove odd line in compile errors

### DIFF
--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -47,8 +47,7 @@ function makeProgressLogger(report /*: typeof Report.Report */) {
         process.stdout.write(`${items.join(' > ')}\r`);
       }
     },
-    logLine(message) {
-      this.log(message);
+    newLine() {
       items.length = 0;
       if (!Report.isMachineReadable(report)) {
         process.stdout.write('\n');
@@ -240,7 +239,8 @@ function runTests(
 
       Generate.prepareCompiledJsFile(pipeFilename, dest);
 
-      progressLogger.logLine('Starting tests');
+      progressLogger.log('Starting tests');
+      progressLogger.newLine();
 
       return await Supervisor.run(
         packageInfo.version,
@@ -251,7 +251,7 @@ function runTests(
         watch
       );
     } catch (err) {
-      progressLogger.logLine('');
+      progressLogger.newLine();
       console.error(err.message);
       return 1;
     }


### PR DESCRIPTION
Before:

```
❯ ../bin/elm-test
-- UNFINISHED DEFINITION - /Users/lydell/forks/node-test-runner/example-application/tests/TestsPassing.elm

I got stuck while parsing the `x` definition:

3| x
    ^
I was expecting to see an argument or an equals sign next.

Here is a valid definition (with a type annotation) for reference:

    greet : String -> String
    greet name =
      "Hello " ++ name ++ "!"

The top line (called a "type annotation") is optional. You can leave it off if
you want. As you get more comfortable with Elm and as your project grows, it
becomes more and more valuable to add them though! They work great as
compiler-verified documentation, and they often improve error messages!

Compiling >
`elm make` failed with exit code 1.
```

After:

```
❯ ../bin/elm-test
-- UNFINISHED DEFINITION - /Users/lydell/forks/node-test-runner/example-application/tests/TestsPassing.elm

I got stuck while parsing the `x` definition:

3| x
    ^
I was expecting to see an argument or an equals sign next.

Here is a valid definition (with a type annotation) for reference:

    greet : String -> String
    greet name =
      "Hello " ++ name ++ "!"

The top line (called a "type annotation") is optional. You can leave it off if
you want. As you get more comfortable with Elm and as your project grows, it
becomes more and more valuable to add them though! They work great as
compiler-verified documentation, and they often improve error messages!


`elm make` failed with exit code 1.
```

Notice the `Compile >` line near the bottom in the “Before” output. That’s not supposed to be there.

I fixed this by reverting the change here: https://github.com/rtfeldman/node-test-runner/pull/480#discussion_r550884417
