### PR TITLE
Fix --no-color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/). This project mirrors major Elm versions. So version 0.18.\* of this project will be compatible with Elm 0.18.\*.
 
+## 0.19.1-revision6 - not released yet
+
+### Fixed
+
+- The `--no-color` and `--color` flags (to disable and force colors) now work again (regression in 0.19.1-revision5).
+
 ## 0.19.1-revision5 - 2020-01-28
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/). This proj
 ### Fixed
 
 - The `--no-color` and `--color` flags (to disable and force colors) now work again (regression in 0.19.1-revision5).
+- `--no-color` now turns off colors in Elm compiler error messages as well.
 
 ## 0.19.1-revision5 - 2020-01-28
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,6 @@ elm-test --report json
 
 ### --no-color
 
-> **Note:** `--no-color` and `--color` are broken in version 0.19.1-revision5. See [#491](https://github.com/rtfeldman/node-test-runner/pull/491).
-
 Disable colored console output.
 
 Colors are also disabled when you pipe the output of `elm-test` to another program. You can use `--color` to force the colors back.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ elm-test --report json
 
 ### --no-color
 
+> **Note:** `--no-color` and `--color` are broken in version 0.19.1-revision5. See [#491](https://github.com/rtfeldman/node-test-runner/pull/491).
+
 Disable colored console output.
 
 Colors are also disabled when you pipe the output of `elm-test` to another program. You can use `--color` to force the colors back.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ Specify which format to use for reporting test results. Valid options are:
 elm-test --report json
 ```
 
+### --no-color
+
+Disable colored console output.
+
+Colors are also disabled when you pipe the output of `elm-test` to another program. You can use `--color` to force the colors back.
+
+Alternatively, you can set the environment variable `FORCE_COLOR` to `0` to disable colors, or to any other value to force them.
+
+See [chalk.supportsColor](https://github.com/chalk/chalk#chalksupportscolor) for more information.
+
 ### --compiler
 
 If `elm` is _not_ in your `$PATH` when elm-test runs, or the Elm executable is called something other than `elm`, you can use this flag to point to your installation.

--- a/lib/Compile.js
+++ b/lib/Compile.js
@@ -1,5 +1,6 @@
 //@flow
 
+const { supportsColor } = require('chalk');
 const spawn = require('cross-spawn');
 const ElmCompiler = require('./ElmCompiler');
 const Report = require('./Report');
@@ -63,18 +64,33 @@ function spawnCompiler({ ignoreStdout, cwd }) {
     processArgs /*: Array<string> */,
     processOpts /*: child_process$spawnOpts */
   ) => {
+    // It might seem useless to specify 'pipe' and then just write all data to
+    // `process.stdout`/`process.stderr`, but it does make a difference: The Elm
+    // compiler turns off colors when it’s used in a pipe. In summary:
+    //
+    // 'inherit' -> Colors, automatically written to stdout/stderr
+    // 'pipe' -> No colors, we need to explicitly write to stdout/stderr
+    const stdout = ignoreStdout ? 'ignore' : supportsColor ? 'inherit' : 'pipe';
+    const stderr = supportsColor ? 'inherit' : 'pipe';
+
     const finalOpts = {
       env: process.env,
       ...processOpts,
       cwd,
-      stdio: [
-        process.stdin,
-        ignoreStdout ? 'ignore' : process.stdout,
-        process.stderr,
-      ],
+      stdio: ['inherit', stdout, stderr],
     };
 
-    return spawn(pathToElm, processArgs, finalOpts);
+    const child = spawn(pathToElm, processArgs, finalOpts);
+
+    if (stdout === 'pipe') {
+      child.stdout.on('data', (data) => process.stdout.write(data));
+    }
+
+    if (stderr === 'pipe') {
+      child.stderr.on('data', (data) => process.stderr.write(data));
+    }
+
+    return child;
   };
 }
 

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -113,6 +113,17 @@ function main() {
         .default('console')
         .choices(Report.all)
     )
+    // `chalk.supportsColor` looks at `process.argv` for these flags.
+    // We still need to define them so they appear in `--help` and aren’t
+    // treated as unknown flags.
+    .option(
+      '--no-color',
+      'Disable colored console output (setting FORCE_COLOR=0 also works)',
+    )
+    .option(
+      '--color',
+      'Force colored console output (setting FORCE_COLOR to anything but 0 also works)',
+    )
     .option(
       '--compiler <path>',
       'Use a custom path to an Elm executable (default: elm)',

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -118,11 +118,11 @@ function main() {
     // treated as unknown flags.
     .option(
       '--no-color',
-      'Disable colored console output (setting FORCE_COLOR=0 also works)',
+      'Disable colored console output (setting FORCE_COLOR=0 also works)'
     )
     .option(
       '--color',
-      'Force colored console output (setting FORCE_COLOR to anything but 0 also works)',
+      'Force colored console output (setting FORCE_COLOR to anything but 0 also works)'
     )
     .option(
       '--compiler <path>',


### PR DESCRIPTION
We used to implicitly support `elm-test --no-color` via [chalk.supportsColor](https://github.com/chalk/chalk#chalksupportscolor).

However, when we switched to commander, unknown flags are now errors. Luckily, `FORCE_COLOR=0` still works.

This PR adds `--no-color` and `--color`, so they aren’t treated as unknown flag errors and so they appear in `--help`. I also added `FORCE_COLOR` to `--help`.

Note: `--color=256` is not supported, only `--color`. This is because we only use basic colors, and we don’t want `tests/Foo.elm` to be slurped as the argument to `--color` in `elm-test --color tests/Foo.elm`.