### PR TITLE
Support `"type": "module"` in package.json

### DIFF
--- a/example-application/package.json
+++ b/example-application/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -36,6 +36,13 @@ var pipeFilename = ${JSON.stringify(pipeFilename)};
 ${after}
   `.trim();
   fs.writeFileSync(dest, finalContent);
+
+  // Needed when the user has `"type": "module"` in their package.json.
+  // Our output is CommonJS.
+  fs.writeFileSync(
+    path.join(path.dirname(dest), 'package.json'),
+    JSON.stringify({ type: 'commonjs' })
+  );
 }
 
 // For older versions of elm-explorations/test we need to list every single


### PR DESCRIPTION
How to reproduce the issue:

```
❯ echo '{ "private": true, "type": "module" }' > package.json

❯ npm i elm-test

❯ elm init

❯ npx elm-test init

❯ npx elm-test
Solving dependencies > Compiling > Starting tests
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
  file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
  at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)


There was an unexpected runtime exception while running tests


file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)

file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24
  FileList = function () {};
           ^

ReferenceError: FileList is not defined
    at file:///Users/lydell/stuff/elm-test-module/elm-stuff/generated-code/elm-community/elm-test/0.19.1-revision6/elmTestOutput.js:24:12
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
```

@mpizenberg I think you’ll be interested in this for elm-test-rs as well.