### PR TITLE
Fix "no tests found" errors for json and junit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,6 @@
                 "mocha/no-exports": "error",
                 "mocha/no-identical-title": "error",
                 "mocha/no-nested-tests": "error",
-                "mocha/no-setup-in-describe": "error",
                 "mocha/no-skipped-tests": "error"
             }
         }

--- a/lib/Supervisor.js
+++ b/lib/Supervisor.js
@@ -28,19 +28,14 @@ function run(
     var startingTime = Date.now();
     var workers = [];
 
-    function printResult(result, exitCode /*: number | void */ = undefined) {
+    function printResult(result) {
       switch (report) {
         case 'console':
           // todos are objects, and will be shown in the SUMMARY only.
           // passed tests are nulls, and should not be printed.
           // failed tests are strings.
           if (typeof result === 'string') {
-            const message = makeWindowsSafe(result);
-            if (exitCode === 1) {
-              console.error(message);
-            } else {
-              console.log(message);
-            }
+            console.log(makeWindowsSafe(result));
           }
           break;
 
@@ -161,15 +156,25 @@ function run(
           case 'SUMMARY':
             flushResults();
 
-            printResult(response.message, response.exitCode);
+            if (response.exitCode === 1) {
+              // The tests could not even run. At the time of this writing, the
+              // only case is “No exposed values of type Test found”. That
+              // _could_ have been caught at compile time, but the current
+              // architecture needs to actually run the JS to figure out which
+              // exposed values are of type Test. That’s why this type of
+              // response is handled differently than others.
+              console.error(response.message);
+            } else {
+              printResult(response.message);
 
-            if (report === 'junit') {
-              var xml = response.message;
-              var values = Array.from(results.values());
+              if (report === 'junit') {
+                var xml = response.message;
+                var values = Array.from(results.values());
 
-              xml.testsuite.testcase = xml.testsuite.testcase.concat(values);
+                xml.testsuite.testcase = xml.testsuite.testcase.concat(values);
 
-              console.log(XmlBuilder.create(xml).end());
+                console.log(XmlBuilder.create(xml).end());
+              }
             }
 
             // Close all the workers.

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -228,4 +228,32 @@ describe('Testing elm-test on single Elm files', () => {
     const filesFound = readdir(path.join(cwd, 'tests', 'RuntimeException'));
     assert.deepStrictEqual(filesFound, erroredTestFiles);
   });
+
+  // tests that fail at compile time
+  const compilerErrorTestFiles = {
+    'InvalidSyntax.elm': 'endless comment',
+    'NoTests.elm': 'no exposed values of type test',
+  };
+
+  for (const [testToRun, output] of Object.entries(compilerErrorTestFiles)) {
+    for (const reporter of ['console', 'junit', 'json']) {
+      it(`Compile errors should go to stderr for test: ${testToRun}, reporter: ${reporter}`, () => {
+        const itsPath = path.join('tests', 'CompileError', testToRun);
+        const runResult = execElmTest([itsPath, '--report', reporter], cwd);
+        assert(
+          runResult.stderr.toLowerCase().includes(output),
+          runResult.stderr
+        );
+        assert.deepStrictEqual(
+          runResult.stdout.split('\n').slice(1).join('\n').trim(),
+          ''
+        );
+      });
+    }
+  }
+
+  it(`Should run every file in tests/CompileError`, () => {
+    const filesFound = readdir(path.join(cwd, 'tests', 'CompileError'));
+    assert.deepStrictEqual(filesFound, erroredTestFiles);
+  });
 });

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -254,6 +254,6 @@ describe('Testing elm-test on single Elm files', () => {
 
   it(`Should run every file in tests/CompileError`, () => {
     const filesFound = readdir(path.join(cwd, 'tests', 'CompileError'));
-    assert.deepStrictEqual(filesFound, erroredTestFiles);
+    assert.deepStrictEqual(filesFound, Object.keys(compilerErrorTestFiles).sort());
   });
 });

--- a/tests/ci.js
+++ b/tests/ci.js
@@ -254,6 +254,9 @@ describe('Testing elm-test on single Elm files', () => {
 
   it(`Should run every file in tests/CompileError`, () => {
     const filesFound = readdir(path.join(cwd, 'tests', 'CompileError'));
-    assert.deepStrictEqual(filesFound, Object.keys(compilerErrorTestFiles).sort());
+    assert.deepStrictEqual(
+      filesFound,
+      Object.keys(compilerErrorTestFiles).sort()
+    );
   });
 });

--- a/tests/fixtures/tests/CompileError/NoTests.elm
+++ b/tests/fixtures/tests/CompileError/NoTests.elm
@@ -1,0 +1,9 @@
+module CompileError.NoTests exposing (somethingElse)
+
+import Expect
+import Test exposing (..)
+
+
+somethingElse : Int
+somethingElse =
+    6


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/node-test-runner/issues/495

I consider this something that _should_ be a compile time error. It isn’t currently because we run the JS to figure out which exposed values are of type Test. But it used to be in 0.19.1-revision4 and older.

All compile time errors are printed human readable to stderr. This PR makes sure that happens for this error as well. There was already code in place for this, but it was only for the `console` reporter. I changed it to apply to all reporters.

I have not been able to figure out how to do a regression test for this.