### PR TITLE
Validate `--fuzz` minimum value earlier

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -17,12 +17,16 @@ const RunTests = require('./RunTests');
 
 void Report;
 
-const parsePositiveInteger = (string /*: string */) /*: number */ => {
+const parsePositiveInteger = (minimum /*: number */) => (
+  string /*: string */
+) /*: number */ => {
   const number = Number(string);
   if (!/^\d+$/.test(string)) {
     throw new InvalidOptionArgumentError('Expected one or more digits.');
   } else if (!Number.isFinite(number)) {
     throw new InvalidOptionArgumentError('Expected a finite number.');
+  } else if (number < minimum) {
+    throw new InvalidOptionArgumentError(`Expected at least ${minimum}.`);
   } else {
     return number;
   }
@@ -97,12 +101,12 @@ function main() {
     .addOption(
       new Option('--seed <int>', 'Run with a specific fuzzer seed')
         .default(Math.floor(Math.random() * 407199254740991) + 1000, 'random')
-        .argParser(parsePositiveInteger)
+        .argParser(parsePositiveInteger(0))
     )
     .option(
       '--fuzz <int>',
       'Define how many times each fuzz-test should run',
-      parsePositiveInteger,
+      parsePositiveInteger(1),
       100
     )
     .addOption(

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -308,6 +308,17 @@ describe('flags', () => {
 
       assert.strictEqual('12345', firstOutput.initialSeed);
     }).timeout(60000);
+
+    it('Should allow 0', () => {
+      const runResult = execElmTest([
+        '--report=json',
+        '--seed=0',
+        path.join('tests', 'Passing', 'One.elm'),
+      ]);
+      const firstOutput = JSON.parse(runResult.stdout.split('\n')[0]);
+
+      assert.strictEqual('0', firstOutput.initialSeed);
+    }).timeout(60000);
   });
 
   describe('--fuzz', () => {
@@ -315,6 +326,17 @@ describe('flags', () => {
       const runResult = execElmTest([
         '--fuzz',
         '0xaf',
+        path.join('tests', 'Passing', 'One.elm'),
+      ]);
+
+      assert.ok(Number.isInteger(runResult.status));
+      assert.notStrictEqual(runResult.status, 0);
+    }).timeout(5000);
+
+    it('Should fail if given 0', () => {
+      const runResult = execElmTest([
+        '--fuzz',
+        '0',
         path.join('tests', 'Passing', 'One.elm'),
       ]);
 


### PR DESCRIPTION
Inspired by https://github.com/mpizenberg/elm-test-rs/issues/74, make `--fuzz 0` an error already in CLI parsing, not when running the tests.

Before:

```
❯ elm-test --fuzz 0
Compiling > Starting tests

elm-test 0.19.1-revision6
-------------------------

Running 0 tests. To reproduce these results, run: elm-test --fuzz 0 --seed 347637688619170


TEST RUN INCOMPLETE because Test runner run count must be at least 1, not 0

Duration: 214 ms
Passed:   0
Failed:   0
```

After:

```
❯ elm-test --fuzz 0
error: option '--fuzz <int>' argument '0' is invalid. Expected at least 1.
```