### PR TITLE
Ignore null output option

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -133,14 +133,16 @@ function main() {
       'Use a custom path to an Elm executable (default: elm)',
       undefined
     )
-    .option(
-      "--output <output>",
-      "Allowed for compatibility with `elm make`. The only supported value is /dev/null, which is ignored since elm-test does not produce any output files.",
-      function(value) {
-        if (value !== "/dev/null") {
-         throw new InvalidOptionArgumentError("Only /dev/null is allowed.");
-        }
-      }
+    .addOption(
+      new Option(
+        "--output <output>",
+        "Allowed for compatibility with `elm make`. The only supported value is /dev/null, which is ignored since elm-test does not produce any output files."
+      ).argParser(function(value) {
+          if (value !== "/dev/null") {
+            throw new InvalidOptionArgumentError("Only /dev/null is allowed.");
+          }
+        })
+       .hideHelp()
     )
     .version(packageInfo.version, '--version', 'Print version and exit')
     .helpOption('-h, --help', 'Show help')

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -133,6 +133,15 @@ function main() {
       'Use a custom path to an Elm executable (default: elm)',
       undefined
     )
+    .option(
+      "--output <output>",
+      "Allowed for compatibility with `elm make`. The only supported value is /dev/null, which is ignored since elm-test does not produce any output files.",
+      function(value) {
+        if (value !== "/dev/null") {
+         throw new InvalidOptionArgumentError("Only /dev/null is allowed.");
+        }
+      }
+    )
     .version(packageInfo.version, '--version', 'Print version and exit')
     .helpOption('-h, --help', 'Show help')
     .addHelpCommand('help [command]', 'Show help');

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -136,7 +136,7 @@ function main() {
     .addOption(
       new Option(
         "--output <output>",
-        "Allowed for compatibility with `elm make`. The only supported value is /dev/null, which is ignored since elm-test does not produce any output files."
+        "Allowed for compatibility with `elm make`. The only supported value is /dev/null, which elm-test ignores since it does not produce any output files."
       ).argParser(function(value) {
           if (value !== "/dev/null") {
             throw new InvalidOptionArgumentError("Only /dev/null is allowed.");

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -78,6 +78,17 @@ function getPathToElmBinary(compiler /*: string | void */) /*: string */ {
   }
 }
 
+function outputOptionError() {
+  return `
+Only /dev/null is allowed.
+
+NOTE: Including this option will not have any effect, as \`elm-test\` does not
+produce any output files. It is meant to improve compatibility with editor
+plugins explicitly setting the --output flag to /dev/null when using
+\`elm-test make\` as a drop-in replacement for \`elm make\`.'
+  `.trim();
+}
+
 const examples = `
 elm-test
   Run tests in the tests/ folder
@@ -139,9 +150,7 @@ function main() {
       new Option('--output <output>')
         .argParser((value) => {
           if (value !== '/dev/null') {
-            throw new InvalidOptionArgumentError(
-              'Only /dev/null is allowed.\n\nNOTE: Including this option will not have any effect, as `elm-test` does not produce any output files. It is meant to improve compatibility with editor plugins explicitly setting the --output flag to /dev/null when using `elm-test make` as a drop-in replacement for `elm make`.'
-            );
+            throw new InvalidOptionArgumentError(outputOptionError());
           }
         })
         .hideHelp()

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -133,16 +133,18 @@ function main() {
       'Use a custom path to an Elm executable (default: elm)',
       undefined
     )
+    // Ensure compatibility with editor plugins setting --output=/dev/null when
+    // running `make`. This has caused issues with Emacs' flycheck-elm package.
     .addOption(
-      new Option(
-        "--output <output>",
-        "Allowed for compatibility with `elm make`. The only supported value is /dev/null, which elm-test ignores since it does not produce any output files."
-      ).argParser(function(value) {
-          if (value !== "/dev/null") {
-            throw new InvalidOptionArgumentError("Only /dev/null is allowed.");
+      new Option('--output <output>')
+        .argParser((value) => {
+          if (value !== '/dev/null') {
+            throw new InvalidOptionArgumentError(
+              'Only /dev/null is allowed.\n\nNOTE: Including this option will not have any effect, as `elm-test` does not produce any output files. It is meant to improve compatibility with editor plugins explicitly setting the --output flag to /dev/null when using `elm-test make` as a drop-in replacement for `elm make`.'
+            );
           }
         })
-       .hideHelp()
+        .hideHelp()
     )
     .version(packageInfo.version, '--version', 'Print version and exit')
     .helpOption('-h, --help', 'Show help')

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -189,6 +189,28 @@ describe('flags', () => {
       assert.ok(Number.isInteger(runResult.status));
       assert.notStrictEqual(runResult.status, 0);
     }).timeout(60000);
+
+    describe('--output', () => {
+      it('should ignore --output flag when set to /dev/null', () => {
+        const runResult = execElmTest([
+          'make',
+          '--output=/dev/null',
+          'tests/Passing/One.elm',
+        ]);
+
+        assert.strictEqual(runResult.status, 0);
+      }).timeout(60000);
+
+      it('should fail if setting --output to anything other than /dev/null', () => {
+        const runResult = execElmTest([
+          'make',
+          '--output=output_file',
+          'tests/Passing/One.elm',
+        ]);
+
+        assert.notStrictEqual(runResult.status, 0);
+      }).timeout(60000);
+    });
   });
 
   describe('--help', () => {

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -208,6 +208,7 @@ describe('flags', () => {
           'tests/Passing/One.elm',
         ]);
 
+        assert.ok(Number.isInteger(runResult.status));
         assert.notStrictEqual(runResult.status, 0);
       }).timeout(60000);
     });


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/node-test-runner/issues/508

Added a `--output` option for interface compatibility with `elm make`.

Note that:
  - When the option is present, elm-test will fail if anything other than `/dev/null` is passed
  - The option is omitted from `--help`, as suggested by @lydell 
  - I tried logging to stdout and stderr when `--output=/dev/null` is supplied but that didn't play well with my editor plugin. I understand that stderr doesn't work because that's where any plugins will try to read the errors json from, but still would expect stdout to work 🤷 . I didn't look into it in detail, but can do it if you all think it's worth it.