### PR TITLE
Drop Node.js 10

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [15.x]
+        node-version: [16.x]
 
     env:
       ELM_HOME: '${{ github.workspace }}/elm-stuff/elm-home'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
 
     env:
       ELM_HOME: '${{ github.workspace }}/elm-stuff/elm-home'

--- a/lib/FindTests.js
+++ b/lib/FindTests.js
@@ -9,15 +9,6 @@ const Project = require('./Project');
 
 void Project;
 
-// We can replace this with using `Array.prototype.flatMap` once Node.js 10 is
-// EOL 2021-04-30 and support for Node.js 10 is dropped.
-function flatMap/*:: <T, U> */(
-  array /*: Array<T> */,
-  f /*: (T) => Array<U> */
-) /*: Array<U> */ {
-  return array.reduce((result, item) => result.concat(f(item)), []);
-}
-
 // Double stars at the start and end is the correct way to ignore directories in
 // the `glob` package.
 // https://github.com/isaacs/node-glob/issues/270#issuecomment-273949982
@@ -30,7 +21,7 @@ function resolveGlobs(
 ) /*: Array<string> */ {
   return Array.from(
     new Set(
-      flatMap(fileGlobs, (fileGlob) => {
+      fileGlobs.flatMap((fileGlob) => {
         const absolutePath = path.resolve(fileGlob);
         try {
           const stat = fs.statSync(absolutePath);
@@ -67,8 +58,8 @@ function resolveCliArgGlob(
     projectRootDir,
     path.resolve(fileGlob)
   );
-  return flatMap(
-    glob.sync(globRelativeToProjectRoot, {
+  return glob
+    .sync(globRelativeToProjectRoot, {
       cwd: projectRootDir,
       nocase: true,
       absolute: true,
@@ -76,10 +67,10 @@ function resolveCliArgGlob(
       // Match directories as well and mark them with a trailing slash.
       nodir: false,
       mark: true,
-    }),
-    (filePath) =>
+    })
+    .flatMap((filePath) =>
       filePath.endsWith('/') ? findAllElmFilesInDir(filePath) : filePath
-  );
+    );
 }
 
 // Recursively search for *.elm files.

--- a/lib/Install.js
+++ b/lib/Install.js
@@ -24,9 +24,11 @@ function install(
     // `fs.rmSync` was added in Node.js 14.14.0, which is also when the
     // `recursive` option of `fs.rmdirSync` was deprecated. The `if` avoids
     // printing a deprecation message.
+    // $FlowFixMe[prop-missing]: Flow does not know of `fs.rmSync` yet.
     if (fs.rmSync !== undefined) {
       fs.rmSync(installationScratchDir, { recursive: true, force: true });
     } else if (fs.existsSync(installationScratchDir)) {
+      // $FlowFixMe[extra-arg]: Flow does not know of the options argument yet.
       fs.rmdirSync(installationScratchDir, { recursive: true });
     }
     fs.mkdirSync(installationScratchDir, { recursive: true });

--- a/lib/Install.js
+++ b/lib/Install.js
@@ -3,7 +3,6 @@
 const spawn = require('cross-spawn');
 const fs = require('fs');
 const path = require('path');
-const rimraf = require('rimraf');
 const ElmJson = require('./ElmJson');
 const Project = require('./Project');
 
@@ -20,10 +19,15 @@ function install(
     // Recreate the directory to remove any artifacts from the last time
     // someone ran `elm-test install`. We do not delete this directory after
     // the installation finishes in case the user needs to debug the test run.
-    if (fs.existsSync(installationScratchDir)) {
-      // We can replace this with `fs.rmdirSync(dir, { recursive: true })`
-      // once Node.js 10 is EOL 2021-04-30 and support for Node.js 10 is dropped.
-      rimraf.sync(installationScratchDir);
+    // We can replace this with just `fs.rmSync(installationScratchDir, { recursive: true, force: true })`
+    // when Node.js 12 is EOL 2022-04-30 and support for Node.js 12 is dropped.
+    // `fs.rmSync` was added in Node.js 14.14.0, which is also when the
+    // `recursive` option of `fs.rmdirSync` was deprecated. The `if` avoids
+    // printing a deprecation message.
+    if (fs.rmSync !== undefined) {
+      fs.rmSync(installationScratchDir, { recursive: true, force: true });
+    } else if (fs.existsSync(installationScratchDir)) {
+      fs.rmdirSync(installationScratchDir, { recursive: true });
     }
     fs.mkdirSync(installationScratchDir, { recursive: true });
   } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -947,9 +947,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.156.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.156.0.tgz",
-      "integrity": "sha512-KEEsKV7/bePZM3Ja7rYlAaSx8GPiTGr7pt0IJcX5S3GSEIZ2ieayF6JWNjbyLiu7ZUJuWe4ITDnPvyqimUpYww==",
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.169.0.tgz",
+      "integrity": "sha512-CflYPrd4KiMh5RyvoJbkM5Az1PKDzFBCu3tHqNcZkHeCbYgtLAcYVTs1w8aKDXfTiBSPZ7B9u5KT5RdmsY2mzQ==",
       "dev": true
     },
     "folder-hash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1789,6 +1789,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.13.0"
   },
   "scripts": {
     "prepare": "elm-tooling install",
@@ -51,7 +51,6 @@
     "elm-tooling": "^1.2.0",
     "glob": "^7.1.6",
     "graceful-fs": "^4.2.4",
-    "rimraf": "^3.0.2",
     "split": "^1.0.1",
     "which": "^2.0.2",
     "xmlbuilder": "^15.1.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "elm-review": "2.5.3",
     "eslint": "7.31.0",
     "eslint-plugin-mocha": "8.0.0",
-    "flow-bin": "0.156.0",
+    "flow-bin": "0.169.0",
     "mocha": "8.3.0",
     "prettier": "2.3.2",
     "strip-ansi": "6.0.0",


### PR DESCRIPTION
Closes #515

Node.js 10 became end-of-life 2021-04-30.

There is a pull request that needs `worker_threads`: https://github.com/rtfeldman/node-test-runner/pull/558.

The `worker_threads` module technically exists in Node.js 10, but is behind the `--experimental-worker`. In Node.js 12 the module is marked as stable and can be used without flags.

Since Node.js 10 has been end-of-life for many months now and we need newer features, it’s time to drop support for Node.js 10.

The new lowest supported version is Node.js 12.13.0, which is the oldest long term support release of Node.js 12: https://nodejs.org/es/blog/release/v12.13.0/

This PR:

- Updates the minium Node.js version to 12.13.0.
- Drops Node.js 10 from CI.
- Drops Node.js 15 from CI (since odd version numbers have short  support, and Node.js 15 is end of life), and adds Node.js 16 (newest  long term support) and Node.js 17 (current latest version).
- Resolves “we can do _this_ instead when Node.js 10 is dropped”  comments in the code.
- The above point replaced the `rimraf` dependency with native `fs` functions. However, Flow does not know of them. I tried updating Flow, but it didn’t help. So I had to add `$FlowFixMe` suppression comments there.