### PR TITLE
Fix parsing of char literals with unicode escapes

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -266,7 +266,10 @@ const backslashableChars = new Set([
   '"',
   "'",
   '\\',
-  // `u` must be followed by `{1234}` but we don’t bother.
+  // Note: `u` must be followed by for example `{1234}`.
+  // In strings and multiline strings, we can just pretend that `\u` is the
+  // escape and `{1234}` is just regular text, for simplicity.
+  // In char literals, we need some extra handling.
   'u',
 ]);
 
@@ -359,6 +362,7 @@ const TokenizerState /*:
   | { tag: 'Maybe..' }
   | { tag: 'CharStart' }
   | { tag: 'CharBackslash' }
+  | { tag: 'CharUnicodeEscape' }
   | { tag: 'CharEnd' }
   | { tag: 'StringStart' }
   | { tag: 'StringContent' }
@@ -544,10 +548,50 @@ function tokenize(
       }
 
     case 'CharBackslash':
-      if (backslashableChars.has(char)) {
+      if (char === 'u') {
+        return [{ tag: 'CharUnicodeEscape' }, []];
+      } else if (backslashableChars.has(char)) {
         return [{ tag: 'CharEnd' }, []];
       } else {
         return backslashError(char);
+      }
+
+    case 'CharUnicodeEscape':
+      switch (char) {
+        case "'":
+          return [
+            { tag: 'Initial', otherTokenChars: '' },
+            [{ tag: 'FlushToken', token: { tag: 'Char' } }],
+          ];
+        // Note: This allows invalid escapes like `\u}abc{1` or `\u{FFFFFFFFFF}`.
+        // It’s not worth parsing this exactly – see the comment at the top of this file.
+        case '{':
+        case '}':
+        case 'a':
+        case 'A':
+        case 'b':
+        case 'B':
+        case 'c':
+        case 'C':
+        case 'd':
+        case 'D':
+        case 'e':
+        case 'E':
+        case 'f':
+        case 'F':
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+          return [{ tag: 'CharUnicodeEscape' }, []];
+        default:
+          return expected("a valid unicode escape or `'`", char);
       }
 
     case 'CharEnd':

--- a/tests/Parser.js
+++ b/tests/Parser.js
@@ -102,6 +102,22 @@ user
         ['user']
       ));
 
+    it('handles escapes in string literals and char literals', () =>
+      testParser(
+        `
+module Main exposing ( ..)
+
+string = "\\n\\r\\t\\"\\'\\\\\\u{00A0}"
+
+chars = [ '\\n', '\\r', '\\t', '\\"', '\\'', '\\\\', '\\u{00A0}' ]
+
+test = something
+--}
+
+`,
+        ['string', 'chars', 'test']
+      ));
+
     it('handles tokens that look like the start of some other token at the end of a line', () =>
       testParser(
         `
@@ -136,7 +152,7 @@ testSubtraction =
         ['one', 'two']
       ));
 
-    it('handles finds test in a file with `exposting (..)` and CRLF', () =>
+    it('handles finds test in a file with `exposing (..)` and CRLF', () =>
       testParser(
         `module Main exposing (..)
 


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/node-test-runner/issues/581

Note: I had a hard time deciding how “well” we should parse this. elm-test doesn’t care at all what’s inside strings and char literals – it just needs to “get past them” without being confused about later syntax. I think I ended up with a good trade-off in the end. See the code comments in the diff for more details.