### PR TITLE
Remove reversing step for offline versions

### DIFF
--- a/lib/DependencyProvider.js
+++ b/lib/DependencyProvider.js
@@ -115,7 +115,7 @@ class OnlineAvailableVersionLister {
     for (const version of offlineVersions) {
       allVersionsSet.add(version);
     }
-    const allVersions = [...allVersionsSet].sort(semverCompare).reverse();
+    const allVersions = [...allVersionsSet].sort(semverCompare);
     this.memoCache.set(pkg, allVersions);
     return allVersions;
   }
@@ -149,11 +149,7 @@ function readVersionsInElmHomeAndSort(pkg /*: string */) /*: Array<string> */ {
     offlineVersions = [];
   }
 
-  offlineVersions.sort(semverCompare);
-
-  // Reverse order of subdirectories to have newest versions first.
-  offlineVersions.reverse();
-  return offlineVersions;
+  return offlineVersions.sort(semverCompare);
 }
 
 class DependencyProvider {
@@ -258,7 +254,7 @@ function onlineVersionsFromScratch(
 // Helper functions ##################################################
 
 function semverCompare(a /*: string */, b /*: string */) /*: number */ {
-  return collator.compare(a, b);
+  return -collator.compare(a, b);
 }
 
 function parseOnlineVersions(

--- a/lib/DependencyProvider.js
+++ b/lib/DependencyProvider.js
@@ -115,7 +115,7 @@ class OnlineAvailableVersionLister {
     for (const version of offlineVersions) {
       allVersionsSet.add(version);
     }
-    const allVersions = [...allVersionsSet].sort(semverCompare);
+    const allVersions = [...allVersionsSet].sort(flippedSemverCompare);
     this.memoCache.set(pkg, allVersions);
     return allVersions;
   }
@@ -149,7 +149,7 @@ function readVersionsInElmHomeAndSort(pkg /*: string */) /*: Array<string> */ {
     offlineVersions = [];
   }
 
-  return offlineVersions.sort(semverCompare);
+  return offlineVersions.sort(flippedSemverCompare);
 }
 
 class DependencyProvider {
@@ -253,8 +253,9 @@ function onlineVersionsFromScratch(
 
 // Helper functions ##################################################
 
-function semverCompare(a /*: string */, b /*: string */) /*: number */ {
-  return -collator.compare(a, b);
+/* Compares two versions so that newer versions appear first when sorting with this function. */
+function flippedSemverCompare(a /*: string */, b /*: string */) /*: number */ {
+  return collator.compare(b, a);
 }
 
 function parseOnlineVersions(


### PR DESCRIPTION
We were sorting then reversing the list in 2 locations. It's more efficient to sort in the opposite order once.

(cc @mpizenberg who did the original implementation)