### PR TITLE
Release 0.19.1-revision8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/). This proj
 
 ### Breaking
 
-- Removed support for Node.js 10 (which reached end of life 2021-04-30). Node.js 12.20.0 is now the minium supported Node.js version. (Node.js 12 actually reached end of life 2022-04-30, but we decided to keep support for it for a while longer since there was no need of dropping it right now.)
+- Removed support for Node.js 10 (which reached end of life 2021-04-30). Node.js 12.20.0 is now the minimum supported Node.js version. (Node.js 12 actually reached end of life 2022-04-30, but we decided to keep support for it for a while longer since there was no need of dropping it right now.)
 
 ### Added
 
-- The new `elm-test install-unstable-test-master` command installs the `master` version of the [elm-explorations/test library](https://github.com/elm-explorations/test/). **This let’s you TODO.** Big thanks to [Martin Janiczek](https://github.com/Janiczek/)!
+- `elm-test install-unstable-test-master`
+  - which installs the `master` version of the [elm-explorations/test library](https://github.com/elm-explorations/test/) in place of the `1.2.2` version in your `ELM_HOME`
+- `elm-test uninstall-unstable-test-master`
+  - which undoes that
+
+**This let’s you test the upcoming major version of elm-explorations/test.** Big thanks to [Martin Janiczek](https://github.com/Janiczek/)!
 
 ### Changed
 
@@ -48,7 +53,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/). This proj
 
 ### Breaking
 
-- Removed support for Node.js 8 (which reached end of life 2019-12-31). Node.js 10.13.0 is now the minium supported Node.js version.
+- Removed support for Node.js 8 (which reached end of life 2019-12-31). Node.js 10.13.0 is now the minimum supported Node.js version.
 - Removed the undocumented `--verbose` flag. It didn’t do much at all in its current state.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ Notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/). This project mirrors major Elm versions. So version 0.18.\* of this project will be compatible with Elm 0.18.\*.
 
+## 0.19.1-revision8 - 2022-06-20
+
+### Breaking
+
+- Removed support for Node.js 10 (which reached end of life 2021-04-30). Node.js 12.20.0 is now the minium supported Node.js version. (Node.js 12 actually reached end of life 2022-04-30, but we decided to keep support for it for a while longer since there was no need of dropping it right now.)
+
+### Added
+
+- The new `elm-test install-unstable-test-master` command installs the `master` version of the [elm-explorations/test library](https://github.com/elm-explorations/test/). **This let’s you TODO.** Big thanks to [Martin Janiczek](https://github.com/Janiczek/)!
+
+### Changed
+
+- elm-test no longer uses [elm-json](https://github.com/zwilias/elm-json/) to calculate the set of dependencies needed to run your tests. Instead, we use [elm-solve-deps-wasm](https://github.com/mpizenberg/elm-solve-deps-wasm) which basically is a WebAssembly port of the dependency solver in [elm-test-rs](https://github.com/mpizenberg/elm-test-rs). Big thanks to [Matthieu Pizenberg](https://github.com/mpizenberg/)! Benefits of this change:
+
+  - elm-test no longer needs to download the elm-json binary at install time or run time. elm-solve-deps-wasm is a regular, cross platform npm package.
+  - Improves compatibility with [Lamdera](https://lamdera.com/).
+  - elm-solve-deps-wasm works offline to a greater extent than elm-json. Many times it doesn’t need to make any calls to package.elm-lang.org at all!
+
+- elm-test now shows suggestions on misspelled CLI flags.
+
+### Fixed
+
+- If you have `module MyTest exposing (..)` with the expose-all `(..)` _and_ a char literal with a unicode escape, like `'\u{000D}'`, in the same file, elm-test now correctly finds all tests to run in that file. A bug with unicode escape parsing previously caused no tests to be found.
+
 ## 0.19.1-revision7 - 2021-05-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.19.1-revision7",
+  "version": "0.19.1-revision8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-test",
-  "version": "0.19.1-revision7",
+  "version": "0.19.1-revision8",
   "description": "Run elm-test suites.",
   "main": "elm-test.js",
   "engines": {


### PR DESCRIPTION
This PR adds Changelog and bump version in package.json.

- [x] Replace `TODO`s in posts
- [ ] Merge
- [ ] Tag
- [ ] Create release on GitHub
- [ ] `npm publish`
- [ ] `npm dist-tag add elm-test@0.19.1-revision8 elm0.19.1`
- [ ] `npm dist-tag add elm-test@0.19.1-revision8 latest-0.19.1`
- [ ] `npm dist-tag elm-test` and check that all looks good
- [ ] Post to Discourse
- [ ] Post on Slack
- [ ] Post on Discord
- [ ] Tweet

<details>

<summary>Discourse/Slack/Discord post</summary>

**Remember to update `@names` for each platform!**

Discourse title: `elm-test 0.19.1-revision8 released!`

```
elm-test 0.19.1-revision8 was just released!

- `elm-test install-unstable-test-master` for testing the upcoming major version of elm-explorations/test! Thanks to @Janiczek!
- Had any problems with the dependency on [elm-json](https://github.com/zwilias/elm-json/)? No more thanks to the new dependency solver by @mattpiz!
- Other small bug fixes and improvements.

The only breaking change was dropping Node.js 10. Upgrade today and try out the new stuff!

https://github.com/rtfeldman/node-test-runner/releases/tag/0.19.1-revision8
```

</details>

<details>

<summary>Twitter post</summary>

```
elm-test 0.19.1-revision8 was just released!

Thanks to @janiczek and @mattpiz for the two bigger contributions of this release!

https://github.com/rtfeldman/node-test-runner/releases/tag/0.19.1-revision8
```

</details>