### PR TITLE
Fix install-unstable-test-master for packages

### DIFF
--- a/lib/Install.js
+++ b/lib/Install.js
@@ -169,28 +169,41 @@ function getDirectTestDependencies(
 
 const PKG = 'elm-explorations/test';
 const VERSION = '1.2.2';
+const VERSION_RANGE = '1.2.2 <= v < 2.0.0';
+
+function getExpectedVersion(
+  project /*: typeof Project.Project */
+) /*: string */ {
+  switch (project.elmJson.type) {
+    case 'application':
+      return VERSION;
+    case 'package':
+      return VERSION_RANGE;
+  }
+}
 
 async function installUnstableTestMaster(
   project /*: typeof Project.Project */
 ) /*: Promise<void> */ {
   const directTestDependencies = getDirectTestDependencies(project);
   const actualVersion = directTestDependencies[PKG];
-  if (actualVersion !== VERSION) {
+  const expectedVersion = getExpectedVersion(project);
+  if (actualVersion !== expectedVersion) {
     throw new Error(
       `
 Could not find ${JSON.stringify(PKG)}: ${JSON.stringify(
-        VERSION
+        expectedVersion
       )} in your elm.json file here:
 
 ${ElmJson.getPath(project.rootDir)}
 
 This command only works if you have ${PKG} as a (direct) test-dependency,
-and only if you use version ${VERSION}.
+and only if you use ${JSON.stringify(expectedVersion)}.
 
 ${
   actualVersion === undefined
     ? 'I could not find it at all.'
-    : `You seem to be using version ${actualVersion}.`
+    : `You seem to be using ${JSON.stringify(actualVersion)}.`
 }
     `.trim()
     );

--- a/lib/Install.js
+++ b/lib/Install.js
@@ -188,7 +188,7 @@ async function installUnstableTestMaster(
   const directTestDependencies = getDirectTestDependencies(project);
   const actualVersion = directTestDependencies[PKG];
   const expectedVersion = getExpectedVersion(project);
-  if (actualVersion !== expectedVersion) {
+  if (actualVersion.replace(/\s/g, '') !== expectedVersion.replace(/\s/g, '')) {
     throw new Error(
       `
 Could not find ${JSON.stringify(PKG)}: ${JSON.stringify(


### PR DESCRIPTION
@jfmengels reported this error when trying `elm-test install-unstable-test-master` on a _package:_

```
npx elm-test install-unstable-test-master
Could not find "elm-explorations/test": "1.2.2" in your elm.json file here:

/home/jeroen/dev/elm-review-unused/elm.json

This command only works if you have elm-explorations/test as a (direct) test-dependency,
and only if you use version 1.2.2.

You seem to be using version 1.2.2 <= v < 2.0.0.
```

For some reason, Elm uses version _ranges_ event for `test-dependencies` for packages. I assumed test-dependencies were always single versions, and never tested packages.

This PR adds supports for packages, in a cheat way. Rather than implementing range calculations, we simply require the exact string `"1.2.2 <= v < 2.0.0"`: (edit: we also allow whitespace differences)

- 1.2.2 was released [June 29, 2019](https://github.com/elm-explorations/test/releases/tag/1.2.2) (three years ago), so people are likely to have that version range.
- If they don’t, it should be ok to have users change to it.