### PR TITLE
Add option to clear the console

### DIFF
--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -43,7 +43,10 @@ function getPipeFilename(runsExecuted /*: number */) /*: string */ {
 // `elm.json changed > Compiling-- NAMING ERROR - File.elm`
 // Also note that using too much `clearLine` or `clearConsole` causes flickering
 // on Windows, so it's nicer to cleverly overwrite old output when possible.
-function makeProgressLogger(report /*: typeof Report.Report */) {
+function makeProgressLogger(
+  report /*: typeof Report.Report */,
+  preserveOutput /*: boolean */
+) {
   const items = [];
   return {
     log(message) {
@@ -67,13 +70,13 @@ function makeProgressLogger(report /*: typeof Report.Report */) {
     },
     clearLine() {
       items.length = 0;
-      if (!Report.isMachineReadable(report)) {
+      if (!Report.isMachineReadable(report) && !preserveOutput) {
         readline.clearLine(process.stdout, 0);
       }
     },
     clearConsole() {
       items.length = 0;
-      if (!Report.isMachineReadable(report)) {
+      if (!Report.isMachineReadable(report) && !preserveOutput) {
         process.stdout.write(
           process.platform === 'win32'
             ? '\x1B[2J\x1B[0f'
@@ -125,11 +128,13 @@ function runTests(
   processes /*: number */,
   {
     watch,
+    preserveOutput,
     report,
     seed,
     fuzz,
   } /*: {
     watch: boolean,
+    preserveOutput: boolean,
     report: typeof Report.Report,
     seed: number,
     fuzz: number,
@@ -141,7 +146,7 @@ function runTests(
   let currentRun /*: Promise<void> | void */ = undefined;
   let queue /*: typeof Queue */ = [];
 
-  const progressLogger = makeProgressLogger(report);
+  const progressLogger = makeProgressLogger(report, preserveOutput);
 
   async function run() /*: Promise<number> */ {
     try {

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -290,8 +290,9 @@ function runTests(
         if (currentRun === undefined) {
           progressLogger.clearConsole();
           if (preserveOutput) {
-            console.log(chalk.blue('\n\n\nRerunning tests due to changes...'));
-            console.log(chalk.blue('=================================\n\n\n'));
+            const message = 'Rerunning tests due to changes...';
+            const separator = '='.repeat(message.length);
+            console.log(chalk.blue(`\n\n\n${message}\n${separator}\n\n\n`));
           }
           progressLogger.log(watcherEventMessage(queue));
           currentRun = run().then(onRunFinish);

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -70,7 +70,7 @@ function makeProgressLogger(
     },
     clearLine() {
       items.length = 0;
-      if (!Report.isMachineReadable(report) && !preserveOutput) {
+      if (!Report.isMachineReadable(report)) {
         readline.clearLine(process.stdout, 0);
       }
     },

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -45,7 +45,7 @@ function getPipeFilename(runsExecuted /*: number */) /*: string */ {
 // on Windows, so it's nicer to cleverly overwrite old output when possible.
 function makeProgressLogger(
   report /*: typeof Report.Report */,
-  preserveOutput /*: boolean */
+  clearConsole /*: boolean */
 ) {
   const items = [];
   return {
@@ -76,7 +76,7 @@ function makeProgressLogger(
     },
     clearConsole() {
       items.length = 0;
-      if (!Report.isMachineReadable(report) && !preserveOutput) {
+      if (!Report.isMachineReadable(report) && clearConsole) {
         process.stdout.write(
           process.platform === 'win32'
             ? '\x1B[2J\x1B[0f'
@@ -128,13 +128,13 @@ function runTests(
   processes /*: number */,
   {
     watch,
-    preserveOutput,
+    clearConsole,
     report,
     seed,
     fuzz,
   } /*: {
     watch: boolean,
-    preserveOutput: boolean,
+    clearConsole: boolean,
     report: typeof Report.Report,
     seed: number,
     fuzz: number,
@@ -146,7 +146,7 @@ function runTests(
   let currentRun /*: Promise<void> | void */ = undefined;
   let queue /*: typeof Queue */ = [];
 
-  const progressLogger = makeProgressLogger(report, preserveOutput);
+  const progressLogger = makeProgressLogger(report, clearConsole);
 
   async function run() /*: Promise<number> */ {
     try {
@@ -289,7 +289,7 @@ function runTests(
         });
         if (currentRun === undefined) {
           progressLogger.clearConsole();
-          if (preserveOutput) {
+          if (!clearConsole) {
             const message = 'Rerunning tests due to changes...';
             const separator = '='.repeat(message.length);
             console.log(chalk.blue(`\n\n\n${message}\n${separator}\n\n\n`));

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -289,6 +289,10 @@ function runTests(
         });
         if (currentRun === undefined) {
           progressLogger.clearConsole();
+          if (preserveOutput) {
+            console.log(chalk.blue('\n\n\nRerunning tests due to changes...'));
+            console.log(chalk.blue('=================================\n\n\n'));
+          }
           progressLogger.log(watcherEventMessage(queue));
           currentRun = run().then(onRunFinish);
         }

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -110,9 +110,8 @@ function main() {
     .description(examples)
     .option('--watch', 'Run tests on file changes', false)
     .option(
-      '--preserve-output',
-      'Preserve output when running with --watch',
-      false
+      '--no-clear-console',
+      "Don't clear the console when running with --watch"
     )
     // For example `--seed` and `--fuzz` only make sense for the “tests” command
     // and could be specified for that command only, but then they won’t show up

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -109,6 +109,11 @@ function main() {
     .usage('[options] [globs...]')
     .description(examples)
     .option('--watch', 'Run tests on file changes', false)
+    .option(
+      '--preserve-output',
+      'Preserve output when running with --watch',
+      false
+    )
     // For example `--seed` and `--fuzz` only make sense for the “tests” command
     // and could be specified for that command only, but then they won’t show up
     // in `--help`.


### PR DESCRIPTION
We are running `elm-test  --watch` with https://github.com/DarthSim/overmind
Unfortunately, it doesn't only clear the output for elm-test, but everything else that is running through overmind.
This PR adds an option to preserve the output and printing a separate between reruns.
Let me know if this makes sense to you or if you want me to change anything. 
Thanks!