### PR TITLE
Fix package link in CLI output

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -187,7 +187,7 @@ function main() {
         throw process.exit(1);
       }
       console.log(
-        `\nCheck out the documentation for getting started at https://package.elm-lang.org/packages/${ElmJson.ELM_TEST_PACKAGE}/test/latest`
+        `\nCheck out the documentation for getting started at https://package.elm-lang.org/packages/${ElmJson.ELM_TEST_PACKAGE}/latest`
       );
       process.exit(0);
     });


### PR DESCRIPTION
`/test` is already included in the `ELM_TEST_PACKAGE` constant.