### PR TITLE
Fix tests

### DIFF
--- a/tests/ElmJson.js
+++ b/tests/ElmJson.js
@@ -45,7 +45,8 @@ describe('handling invalid elm.json', () => {
           ElmJson.requireElmTestPackage(fullPath, elmJson);
         },
         {
-          message: expected,
+          message:
+            dir === 'json-syntax-error' ? new RegExp(expected) : expected,
         }
       );
     });

--- a/tests/fixtures/invalid-elm-json/json-syntax-error/expected.txt
+++ b/tests/fixtures/invalid-elm-json/json-syntax-error/expected.txt
@@ -1,3 +1,3 @@
 /full/path/to/elm.json
 Failed to read elm.json:
-Unexpected string in JSON at position 11
+(Unexpected string|Expected ':' after property name) in JSON at position 11


### PR DESCRIPTION
Allow both the new JSON.parse error and the old one.
Took a minute, but it was easier than I'd expected once I figured out what I was doing.

_**Fixes:** #633._