### PR TITLE
Fix tests due to Node.js changing the JSON.parse error messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.20.0, 12.x, 14.x, 16.x, 18.x]
+        # macOS-13 is the latest macOS version that is x86.
+        # Node.js 12, 14 and 16 aren’t support on the arm64 runners.
+        os: [ubuntu-latest, macOS-13, windows-latest]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
+        # Also have a test on macOS arm64.
+        include:
+          - os: macOS-latest
+            node-version: 22.x
 
     env:
       ELM_HOME: '${{ github.workspace }}/elm-stuff/elm-home'

--- a/elm-tooling.json
+++ b/elm-tooling.json
@@ -2,6 +2,6 @@
     "tools": {
         "elm": "0.19.1",
         "elm-format": "0.8.5",
-        "elm-json": "0.2.10"
+        "elm-json": "0.2.13"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,9 +561,9 @@
       "integrity": "sha512-qnwo7RO9IO7jd9SLHvIy0rSOEIlc/tNMTE9Cras0kl+b161PVidW4FvXo0MtXU8GAKi/2s/HYvhcnpR/NNQ1zw=="
     },
     "elm-tooling": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/elm-tooling/-/elm-tooling-1.10.0.tgz",
-      "integrity": "sha512-fMLXs7xHpr6LodtmvVJKepYC6chgSOfe5Hgv8GcFO+Id7O/CuT9+CAfrlzYxvBn91cm6ekWwHFDjPD765v5iBA==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/elm-tooling/-/elm-tooling-1.15.1.tgz",
+      "integrity": "sha512-+rRYa7gzz6l2/Ip2i197MqkW5abOwPOP/+WlyyatLDeDhh+JR0HUMlZJYenCYodBeG/xW5xW3pRYQ2onf5bIAw==",
       "dev": true
     },
     "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "elm-review": "2.9.1",
-    "elm-tooling": "1.10.0",
+    "elm-tooling": "1.15.1",
     "eslint": "8.31.0",
     "eslint-plugin-mocha": "10.1.0",
     "flow-bin": "0.180.0",

--- a/tests/ElmJson.js
+++ b/tests/ElmJson.js
@@ -44,8 +44,16 @@ describe('handling invalid elm.json', () => {
           const elmJson = ElmJson.read(fullPath);
           ElmJson.requireElmTestPackage(fullPath, elmJson);
         },
-        {
-          message: expected,
+        (error) => {
+          assert.strictEqual(
+            error.message.replace(
+              // Handle slightly different JSON.parse error messages on different Node.js versions.
+              /^.+ in JSON at position .+$/gm,
+              '(the JSON parse error)'
+            ),
+            expected
+          );
+          return true;
         }
       );
     });

--- a/tests/fixtures/invalid-elm-json/json-syntax-error/expected.txt
+++ b/tests/fixtures/invalid-elm-json/json-syntax-error/expected.txt
@@ -1,3 +1,3 @@
 /full/path/to/elm.json
 Failed to read elm.json:
-Unexpected string in JSON at position 11
+(the JSON parse error)


### PR DESCRIPTION
Fixes #633.

Closes #634.

CI failed, due to the test matrix, so updated that too. Then macOS-latest required elm-tooling and elm-json to be updated.