### PR TITLE
Replace glob by tinyglobby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
       matrix:
         # macOS-13 is the latest macOS version that is x86.
         # Node.js 12, 14 and 16 aren’t support on the arm64 runners.
-        os: [ubuntu-latest, macOS-13, windows-latest]
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
+        os: [windows-latest]
+        node-version: [22.x]
         # Also have a test on macOS arm64.
-        include:
-          - os: macOS-latest
-            node-version: 22.x
+        # include:
+        #   - os: macOS-latest
+        #     node-version: 22.x
 
     env:
       ELM_HOME: '${{ github.workspace }}/elm-stuff/elm-home'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,10 +50,6 @@ jobs:
         env:
           NO_ELM_TOOLING_INSTALL: 1
 
-      - name: install glob 8
-        if: steps.cache-node_modules.outputs.cache-hit != 'true' && (matrix.node-version == '12.x' || matrix.node-version == '14.x')
-        run: npm install glob@8
-
       - name: install mocha 9
         if: steps.cache-node_modules.outputs.cache-hit != 'true' && (matrix.node-version == '12.x' || matrix.node-version == '14.x' || matrix.node-version == '16.x')
         run: npm install mocha@9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
       matrix:
         # macOS-13 is the latest macOS version that is x86.
         # Node.js 12, 14 and 16 aren’t support on the arm64 runners.
-        os: [windows-latest]
-        node-version: [22.x]
+        os: [ubuntu-latest, macOS-13, windows-latest]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
         # Also have a test on macOS arm64.
-        # include:
-        #   - os: macOS-latest
-        #     node-version: 22.x
+        include:
+          - os: macOS-latest
+            node-version: 22.x
 
     env:
       ELM_HOME: '${{ github.workspace }}/elm-stuff/elm-home'

--- a/lib/FindTests.js
+++ b/lib/FindTests.js
@@ -71,7 +71,7 @@ function resolveCliArgGlob(
   // https://github.com/isaacs/minimatch/commit/9104d8d175bdd8843338103be1401f80774d2a10#diff-f41746899d033115e03bebe4fbde76acf2de4bf261bfb221744808f4c8a286cf
   const pattern =
     process.platform === 'win32'
-      ? globRelativeToProjectRoot.replace(/\\/g, '/')
+      ? globRelativeToProjectRoot //.replace(/\\/g, '/')
       : globRelativeToProjectRoot;
 
   return globSync(pattern, {

--- a/lib/FindTests.js
+++ b/lib/FindTests.js
@@ -59,19 +59,16 @@ function resolveCliArgGlob(
     path.resolve(fileGlob)
   );
 
-  // glob@8 (via minimatch@5) had a breaking change where you _have_ to use
-  // forwards slash as path separator, regardless of platform, making it
-  // unambiguous which characters are separators and which are escapes. This
-  // restores the previous behavior, avoiding a breaking change in elm-test.
+  // The globs _have_ to use forwards slash as path separator, regardless of
+  // platform, making it unambiguous which characters are separators and which
+  // are escapes.
   // Note: As far I can tell, escaping glob syntax has _never_ worked on
   // Windows. In Elm, needing to escape glob syntax should be very rare, since
   // Elm file paths must match the module name (letters only). So it’s probably
   // more worth supporting `some\folder\*Test.elm` rather than escaping.
-  // https://github.com/isaacs/node-glob/issues/468
-  // https://github.com/isaacs/minimatch/commit/9104d8d175bdd8843338103be1401f80774d2a10#diff-f41746899d033115e03bebe4fbde76acf2de4bf261bfb221744808f4c8a286cf
   const pattern =
     process.platform === 'win32'
-      ? globRelativeToProjectRoot //.replace(/\\/g, '/')
+      ? globRelativeToProjectRoot.replace(/\\/g, '/')
       : globRelativeToProjectRoot;
 
   return globSync(pattern, {

--- a/lib/FindTests.js
+++ b/lib/FindTests.js
@@ -2,7 +2,7 @@
 
 const gracefulFs = require('graceful-fs');
 const fs = require('fs');
-const glob = require('glob');
+const { globSync } = require('tinyglobby');
 const path = require('path');
 const Parser = require('./Parser');
 const Project = require('./Project');
@@ -74,29 +74,27 @@ function resolveCliArgGlob(
       ? globRelativeToProjectRoot.replace(/\\/g, '/')
       : globRelativeToProjectRoot;
 
-  return glob
-    .sync(pattern, {
-      cwd: projectRootDir,
-      nocase: true,
-      absolute: true,
-      ignore: ignoredDirsGlobs,
-      // Match directories as well and mark them with a trailing slash.
-      nodir: false,
-      mark: true,
-    })
-    .flatMap((filePath) =>
-      filePath.endsWith('/') ? findAllElmFilesInDir(filePath) : filePath
-    );
+  return globSync(pattern, {
+    cwd: projectRootDir,
+    caseSensitiveMatch: false,
+    absolute: true,
+    ignore: ignoredDirsGlobs,
+    // Match directories as well
+    onlyFiles: false,
+  }).flatMap((filePath) =>
+    // Directories have their path end with `/`
+    filePath.endsWith('/') ? findAllElmFilesInDir(filePath) : filePath
+  );
 }
 
 // Recursively search for *.elm files.
 function findAllElmFilesInDir(dir /*: string */) /*: Array<string> */ {
-  return glob.sync('**/*.elm', {
+  return globSync('**/*.elm', {
     cwd: dir,
-    nocase: true,
+    caseSensitiveMatch: false,
     absolute: true,
     ignore: ignoredDirsGlobs,
-    nodir: true,
+    onlyFiles: true,
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,6 +165,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "requires": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -177,22 +178,26 @@
         "ansi-regex": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
+          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+          "dev": true
         },
         "ansi-styles": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
         },
         "string-width": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
           "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
           "requires": {
             "eastasianwidth": "^0.2.0",
             "emoji-regex": "^9.2.2",
@@ -203,6 +208,7 @@
           "version": "npm:string-width@4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -212,17 +218,20 @@
             "ansi-regex": {
               "version": "5.0.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+              "dev": true
             },
             "emoji-regex": {
               "version": "8.0.0",
               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+              "dev": true
             },
             "strip-ansi": {
               "version": "6.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+              "dev": true,
               "requires": {
                 "ansi-regex": "^5.0.1"
               }
@@ -233,6 +242,7 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
           "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
           }
@@ -241,6 +251,7 @@
           "version": "npm:strip-ansi@6.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
           "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           },
@@ -248,7 +259,8 @@
             "ansi-regex": {
               "version": "5.0.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+              "dev": true
             }
           }
         },
@@ -256,6 +268,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
           "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^6.1.0",
             "string-width": "^5.0.1",
@@ -266,6 +279,7 @@
           "version": "npm:wrap-ansi@7.0.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
           "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
@@ -275,12 +289,14 @@
             "ansi-regex": {
               "version": "5.0.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+              "dev": true
             },
             "ansi-styles": {
               "version": "4.3.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
               "requires": {
                 "color-convert": "^2.0.1"
               }
@@ -288,12 +304,14 @@
             "emoji-regex": {
               "version": "8.0.0",
               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+              "dev": true
             },
             "string-width": {
               "version": "4.2.3",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
               "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+              "dev": true,
               "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -304,6 +322,7 @@
               "version": "6.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
               "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+              "dev": true,
               "requires": {
                 "ansi-regex": "^5.0.1"
               }
@@ -316,6 +335,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "optional": true
     },
     "@sindresorhus/is": {
@@ -461,7 +481,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -734,7 +755,8 @@
     "eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "elm-review": {
       "version": "2.13.1",
@@ -999,8 +1021,7 @@
     "fdir": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-      "dev": true
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw=="
     },
     "file-entry-cache": {
       "version": "8.0.0",
@@ -1075,6 +1096,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -1083,7 +1105,8 @@
         "signal-exit": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
         }
       }
     },
@@ -1106,19 +1129,6 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "requires": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
       }
     },
     "glob-parent": {
@@ -1236,7 +1246,8 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
@@ -1273,15 +1284,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "requires": {
-        "@isaacs/cliui": "^8.0.2",
-        "@pkgjs/parseargs": "^0.11.0"
-      }
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -1366,11 +1368,6 @@
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true
     },
-    "lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -1383,24 +1380,6 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
-    "minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "requires": {
-        "brace-expansion": "^2.0.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        }
-      }
-    },
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -1410,7 +1389,8 @@
     "minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true
     },
     "mocha": {
       "version": "11.1.0",
@@ -1634,7 +1614,8 @@
     "package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -1655,15 +1636,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    },
-    "path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "requires": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      }
     },
     "picomatch": {
       "version": "2.3.1",
@@ -1922,7 +1894,6 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
       "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
-      "dev": true,
       "requires": {
         "fdir": "^6.4.2",
         "picomatch": "^4.0.2"
@@ -1931,8 +1902,7 @@
         "picomatch": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-          "dev": true
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "commander": "^9.4.1",
     "cross-spawn": "^7.0.6",
     "elm-solve-deps-wasm": "^1.0.2 || ^2.0.0",
-    "glob": "^8.0.3 || ^9.0.0 || ^10.0.0",
     "graceful-fs": "^4.2.10",
     "split": "^1.0.1",
+    "tinyglobby": "^0.2.10",
     "which": "^2.0.2",
     "xmlbuilder": "^15.1.1"
   },

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -704,6 +704,12 @@ describe('flags', () => {
       ]);
       assert.strictEqual(runResult.status, 0);
     }).timeout(60000);
+
+    it('Should find all Elm files inside the directory that a glob resolves to', () => {
+      const runResult = execElmTest(['tests/Pass*']);
+      console.log(runResult);
+      assert.strictEqual(runResult.status, 0);
+    }).timeout(60000);
   });
 
   describe('unknown flags', () => {

--- a/tests/flags.js
+++ b/tests/flags.js
@@ -707,7 +707,6 @@ describe('flags', () => {
 
     it('Should find all Elm files inside the directory that a glob resolves to', () => {
       const runResult = execElmTest(['tests/Pass*']);
-      console.log(runResult);
       assert.strictEqual(runResult.status, 0);
     }).timeout(60000);
   });

--- a/tests/test-quality.js
+++ b/tests/test-quality.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const path = require('path');
-const glob = require('glob');
+const { globSync } = require('tinyglobby');
 const spawn = require('cross-spawn');
 
 const { spawnOpts } = require('./util');
@@ -23,7 +23,7 @@ function execElm(args, cwd) {
   );
 }
 
-let examples = glob.sync(path.join(__dirname, '..', 'example*'));
+let examples = globSync(path.join(__dirname, '..', 'example*'));
 
 describe('examples quality', () => {
   describe('Each example has valid json', () => {


### PR DESCRIPTION
This should I think fix the support for Node.js v12 (and fixes https://github.com/rtfeldman/node-test-runner/issues/646)

> From what I can see, Node.js v12 broken (at least) because of minimatch v9 being used, which only supports 14 and up. minimatch is used because glob@10, so switching to tinyglobby (v12 and up) might be a good solution to the problem actually.
(https://github.com/rtfeldman/node-test-runner/issues/646#issuecomment-2660864905)

Note: I haven't tested it as thoroughly as I'd like to yet, but it seems to work well so far.

The packages are relatively interchangeable, though the options change; Here is the documentation for each:
- tinyglobby: https://www.npmjs.com/package/tinyglobby#Options
- glob: https://www.npmjs.com/package/glob#Options

`nodir` becomes `onlyFiles: true`
`nocase` becomes `caseSensitiveMatch` (but inverted)
I could not find an equivalent to glob's `mark` (Append a / on any directories matched) but that is the default behavior for `tinyglobby` anyway.

From what I can tell, these are the paths through which globbing is used (My understanding of what is happening at least):
In `resolveGlobs`, we look for test files. By default we look for `<root>/tests`, but that can be overridden by CLI arguments (`elm-test otherDir/ tests/SpecificTest.elm`).We first iterate through that list to understand which each of these paths exist or not. If it exists, we defer to `findAllElmFilesInDir` if it's a directory, and just take the file it it's a file. If it does not exist, then it's likely a glob (`elm-test "**/*Test.elm" "te*ts/"`, which we defer to `resolveCliArgGlob` where we apply the glob. For every directory, we then again defer to findAllElmFilesInDir`.

In findAllElmFilesInDir`, we use globbing to find all contained Elm files.