### PR TITLE
Import modules lazily

### DIFF
--- a/lib/Report.js
+++ b/lib/Report.js
@@ -4,8 +4,6 @@
 // https://github.com/prettier/prettier/issues/2597
 const Report /*: 'console' | 'json' | 'junit' */ = 'console';
 
-const all = ['json', 'junit', 'console'];
-
 function isMachineReadable(report /*: typeof Report */) /*: boolean */ {
   switch (report) {
     case 'json':
@@ -18,6 +16,5 @@ function isMachineReadable(report /*: typeof Report */) /*: boolean */ {
 
 module.exports = {
   Report,
-  all,
   isMachineReadable,
 };

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -2,7 +2,6 @@
 
 const chalk = require('chalk');
 const path = require('path');
-const packageInfo = require('../package.json');
 const Compile = require('./Compile');
 const { DependencyProvider } = require('./DependencyProvider.js');
 const ElmJson = require('./ElmJson');
@@ -128,6 +127,7 @@ function watcherEventMessage(
 function runTests(
   dependencyProvider /*: DependencyProvider */,
   projectRootDir /*: string */,
+  packageVersion /*: string */,
   pathToElmBinary /*: string */,
   testFileGlobs /*: Array<string> */,
   processes /*: number */,
@@ -191,7 +191,7 @@ function runTests(
 
       // Files may be changed, added or removed so always re-create project info
       // from disk to stay fresh.
-      const project = Project.init(projectRootDir, packageInfo.version);
+      const project = Project.init(projectRootDir, packageVersion);
       ElmJson.requireElmTestPackage(projectRootDir, project.elmJson);
       Project.validateTestsSourceDirs(project);
 
@@ -248,7 +248,7 @@ function runTests(
       progressLogger.newLine();
 
       return await Supervisor.run(
-        packageInfo.version,
+        packageVersion,
         pipeFilename,
         report,
         processes,

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -2,7 +2,6 @@
 
 const chalk = require('chalk');
 const path = require('path');
-const readline = require('readline');
 const packageInfo = require('../package.json');
 const Compile = require('./Compile');
 const { DependencyProvider } = require('./DependencyProvider.js');
@@ -43,7 +42,9 @@ function getPipeFilename(runsExecuted /*: number */) /*: string */ {
 // Also note that using too much `clearLine` or `clearConsole` causes flickering
 // on Windows, so it's nicer to cleverly overwrite old output when possible.
 function makeHumanReadableProgressLogger(clearConsole /*: boolean */) {
+  let readline;
   const items = [];
+
   return {
     log(message) {
       items.push(message);
@@ -60,6 +61,7 @@ function makeHumanReadableProgressLogger(clearConsole /*: boolean */) {
     },
     clearLine() {
       items.length = 0;
+      readline = readline || require('readline');
       readline.clearLine(process.stdout, 0);
     },
     clearConsole() {

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -1,7 +1,6 @@
 // @flow
 
 const chalk = require('chalk');
-const chokidar = require('chokidar');
 const path = require('path');
 const readline = require('readline');
 const packageInfo = require('../package.json');
@@ -301,6 +300,7 @@ function runTests(
       }
     };
 
+    const chokidar = require('chokidar');
     watcher = chokidar.watch(alwaysWatched, {
       ignoreInitial: true,
       ignored: FindTests.ignoredDirsGlobs,

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -109,7 +109,12 @@ const Queue /*: Array<{
 }> */ = [];
 void Queue;
 
-function watcherEventMessage(queue /*: typeof Queue */) /*: string */ {
+function watcherEventMessage(
+  isHumanReadable /*: boolean */,
+  queue /*: typeof Queue */
+) /*: string */ {
+  if (!isHumanReadable) return '';
+
   const filePaths = Array.from(new Set(queue.map(({ filePath }) => filePath)));
   if (filePaths.length === 1) {
     const { event, filePath } = queue[0];
@@ -173,7 +178,7 @@ function runTests(
         // Re-print the message in case the queue has become longer while waiting.
         if (queue.length > queueLengthBeforeWaiting) {
           progressLogger.clearLine();
-          progressLogger.log(watcherEventMessage(queue));
+          progressLogger.log(watcherEventMessage(isHumanReadable, queue));
         }
       }
 
@@ -263,7 +268,7 @@ function runTests(
     const onRunFinish = () => {
       if (queue.length > 0) {
         progressLogger.clearConsole();
-        progressLogger.log(watcherEventMessage(queue));
+        progressLogger.log(watcherEventMessage(isHumanReadable, queue));
         currentRun = run().then(onRunFinish);
       } else {
         if (!Report.isMachineReadable(report)) {
@@ -297,7 +302,7 @@ function runTests(
             const separator = '='.repeat(message.length);
             console.log(chalk.blue(`\n\n\n${message}\n${separator}\n\n\n`));
           }
-          progressLogger.log(watcherEventMessage(queue));
+          progressLogger.log(watcherEventMessage(isHumanReadable, queue));
           currentRun = run().then(onRunFinish);
         }
       }

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -151,9 +151,10 @@ function runTests(
   let currentRun /*: Promise<void> | void */ = undefined;
   let queue /*: typeof Queue */ = [];
 
-  const progressLogger = Report.isMachineReadable(report)
-    ? makeDummyProgressLogger()
-    : makeHumanReadableProgressLogger(clearConsole);
+  const isHumanReadable = !Report.isMachineReadable(report);
+  const progressLogger = isHumanReadable
+    ? makeHumanReadableProgressLogger(clearConsole)
+    : makeDummyProgressLogger();
 
   async function run() /*: Promise<number> */ {
     try {
@@ -271,7 +272,7 @@ function runTests(
         progressLogger.log(watcherEventMessage(isHumanReadable, queue));
         currentRun = run().then(onRunFinish);
       } else {
-        if (!Report.isMachineReadable(report)) {
+        if (isHumanReadable) {
           console.log(chalk.blue('Watching for changes...'));
         }
         currentRun = undefined;

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -42,41 +42,29 @@ function getPipeFilename(runsExecuted /*: number */) /*: string */ {
 // `elm.json changed > Compiling-- NAMING ERROR - File.elm`
 // Also note that using too much `clearLine` or `clearConsole` causes flickering
 // on Windows, so it's nicer to cleverly overwrite old output when possible.
-function makeProgressLogger(
-  report /*: typeof Report.Report */,
-  clearConsole /*: boolean */
-) {
-  const isHumanReadable = !Report.isMachineReadable(report);
+function makeHumanReadableProgressLogger(clearConsole /*: boolean */) {
   const items = [];
   return {
     log(message) {
       items.push(message);
-      if (isHumanReadable) {
-        process.stdout.write(`${items.join(' > ')}\r`);
-      }
+      process.stdout.write(`${items.join(' > ')}\r`);
     },
     newLine() {
       items.length = 0;
-      if (isHumanReadable) {
-        process.stdout.write('\n');
-      }
+      process.stdout.write('\n');
     },
     overwrite(message) {
       items.length = 0;
       items.push(message);
-      if (isHumanReadable) {
-        process.stdout.write(`${message}\r`);
-      }
+      process.stdout.write(`${message}\r`);
     },
     clearLine() {
       items.length = 0;
-      if (isHumanReadable) {
-        readline.clearLine(process.stdout, 0);
-      }
+      readline.clearLine(process.stdout, 0);
     },
     clearConsole() {
       items.length = 0;
-      if (isHumanReadable && clearConsole) {
+      if (clearConsole) {
         process.stdout.write(
           process.platform === 'win32'
             ? '\x1B[2J\x1B[0f'
@@ -84,6 +72,16 @@ function makeProgressLogger(
         );
       }
     },
+  };
+}
+
+function makeDummyProgressLogger() {
+  return {
+    log(message) {}, // eslint-disable-line no-unused-vars
+    newLine() {},
+    overwrite(message) {}, // eslint-disable-line no-unused-vars
+    clearLine() {},
+    clearConsole() {},
   };
 }
 
@@ -146,7 +144,9 @@ function runTests(
   let currentRun /*: Promise<void> | void */ = undefined;
   let queue /*: typeof Queue */ = [];
 
-  const progressLogger = makeProgressLogger(report, clearConsole);
+  const progressLogger = Report.isMachineReadable(report)
+    ? makeDummyProgressLogger()
+    : makeHumanReadableProgressLogger(clearConsole);
 
   async function run() /*: Promise<number> */ {
     try {

--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -46,36 +46,37 @@ function makeProgressLogger(
   report /*: typeof Report.Report */,
   clearConsole /*: boolean */
 ) {
+  const isHumanReadable = !Report.isMachineReadable(report);
   const items = [];
   return {
     log(message) {
       items.push(message);
-      if (!Report.isMachineReadable(report)) {
+      if (isHumanReadable) {
         process.stdout.write(`${items.join(' > ')}\r`);
       }
     },
     newLine() {
       items.length = 0;
-      if (!Report.isMachineReadable(report)) {
+      if (isHumanReadable) {
         process.stdout.write('\n');
       }
     },
     overwrite(message) {
       items.length = 0;
       items.push(message);
-      if (!Report.isMachineReadable(report)) {
+      if (isHumanReadable) {
         process.stdout.write(`${message}\r`);
       }
     },
     clearLine() {
       items.length = 0;
-      if (!Report.isMachineReadable(report)) {
+      if (isHumanReadable) {
         readline.clearLine(process.stdout, 0);
       }
     },
     clearConsole() {
       items.length = 0;
-      if (!Report.isMachineReadable(report) && clearConsole) {
+      if (isHumanReadable && clearConsole) {
         process.stdout.write(
           process.platform === 'win32'
             ? '\x1B[2J\x1B[0f'

--- a/lib/Solve.js
+++ b/lib/Solve.js
@@ -1,6 +1,5 @@
 // @flow
 
-const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const ElmJson = require('./ElmJson');
@@ -13,6 +12,7 @@ void Project;
 void DependencyProvider;
 
 function sha256(string) {
+  const crypto = require('crypto');
   return crypto.createHash('sha256').update(string).digest('hex');
 }
 

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -4,7 +4,6 @@ const { InvalidOptionArgumentError, Option, program } = require('commander');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const which = require('which');
 const packageInfo = require('../package.json');
 const ElmJson = require('./ElmJson');
 const Install = require('./Install');
@@ -61,6 +60,7 @@ function getProject(subcommand /*: string */) /*: typeof Project.Project */ {
 
 function getPathToElmBinary(compiler /*: string | void */) /*: string */ {
   const name = compiler === undefined ? 'elm' : compiler;
+  const which = require('which');
   try {
     return path.resolve(which.sync(name));
   } catch (_error) {

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -255,6 +255,7 @@ function main() {
       RunTests.runTests(
         dependencyProvider,
         projectRootDir,
+        packageInfo.version,
         pathToElmBinary,
         testFileGlobs,
         processes,

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -5,7 +5,6 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const packageInfo = require('../package.json');
-const ElmJson = require('./ElmJson');
 const Report = require('./Report');
 
 void Report;
@@ -26,6 +25,7 @@ const parsePositiveInteger =
   };
 
 function findClosestElmJson(dir /*: string */) /*: string | void */ {
+  const ElmJson = require('./ElmJson');
   const entry = ElmJson.getPath(dir);
   return fs.existsSync(entry)
     ? entry
@@ -160,9 +160,7 @@ function main() {
 
   program
     .command('init')
-    .description(
-      `Install ${ElmJson.ELM_TEST_PACKAGE} and create tests/Example.elm`
-    )
+    .description('Install elm-explorations/test and create tests/Example.elm')
     .action(() => {
       const Install = require('./Install');
 
@@ -170,7 +168,7 @@ function main() {
       const pathToElmBinary = getPathToElmBinary(options.compiler);
       const project = getProject('init');
       try {
-        Install.install(project, pathToElmBinary, ElmJson.ELM_TEST_PACKAGE);
+        Install.install(project, pathToElmBinary, 'elm-explorations/test');
         fs.mkdirSync(project.testsDir, { recursive: true });
         fs.copyFileSync(
           path.join(__dirname, '..', 'templates', 'tests', 'Example.elm'),
@@ -181,7 +179,7 @@ function main() {
         throw process.exit(1);
       }
       console.log(
-        `\nCheck out the documentation for getting started at https://package.elm-lang.org/packages/${ElmJson.ELM_TEST_PACKAGE}/latest`
+        '\nCheck out the documentation for getting started at https://package.elm-lang.org/packages/elm-explorations/test/latest'
       );
       process.exit(0);
     });

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -5,9 +5,6 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const packageInfo = require('../package.json');
-const Report = require('./Report');
-
-void Report;
 
 const parsePositiveInteger =
   (minimum /*: number */) =>
@@ -125,7 +122,7 @@ function main() {
         'Specify which format to use for reporting test results'
       )
         .default('console')
-        .choices(Report.all)
+        .choices(['json', 'junit', 'console'])
     )
     // `chalk.supportsColor` looks at `process.argv` for these flags.
     // We still need to define them so they appear in `--help` and aren’t

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -23,12 +23,12 @@ const parsePositiveInteger =
 
 function findClosestElmJson(dir /*: string */) /*: string | void */ {
   const ElmJson = require('./ElmJson');
-  const entry = ElmJson.getPath(dir);
-  return fs.existsSync(entry)
-    ? entry
-    : dir === path.parse(dir).root
-    ? undefined
-    : findClosestElmJson(path.dirname(dir));
+  do {
+    const entry = ElmJson.getPath(dir);
+    if (fs.existsSync(entry)) return entry;
+    dir = path.dirname(dir);
+  } while (dir !== path.parse(dir).root);
+  return undefined;
 }
 
 function getProjectRootDir(subcommand /*: string */) /*: string */ {

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -6,7 +6,6 @@ const os = require('os');
 const path = require('path');
 const packageInfo = require('../package.json');
 const ElmJson = require('./ElmJson');
-const Install = require('./Install');
 const Project = require('./Project');
 const Report = require('./Report');
 
@@ -165,6 +164,8 @@ function main() {
       `Install ${ElmJson.ELM_TEST_PACKAGE} and create tests/Example.elm`
     )
     .action(() => {
+      const Install = require('./Install');
+
       const options = program.opts();
       const pathToElmBinary = getPathToElmBinary(options.compiler);
       const project = getProject('init');
@@ -191,6 +192,8 @@ function main() {
       'Like `elm install package`, except it installs to "test-dependencies" in your elm.json'
     )
     .action((packageName) => {
+      const Install = require('./Install');
+
       const options = program.opts();
       const pathToElmBinary = getPathToElmBinary(options.compiler);
       const project = getProject('install');

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -9,7 +9,6 @@ const packageInfo = require('../package.json');
 const Compile = require('./Compile');
 const { DependencyProvider } = require('./DependencyProvider.js');
 const ElmJson = require('./ElmJson');
-const FindTests = require('./FindTests');
 const Generate = require('./Generate');
 const Install = require('./Install');
 const Project = require('./Project');
@@ -224,6 +223,7 @@ function main() {
       const project = getProject('make');
       const make = async () => {
         Generate.generateElmJson(dependencyProvider, project);
+        const FindTests = require('./FindTests');
         await Compile.compileSources(
           FindTests.resolveGlobs(
             testFileGlobs.length === 0 ? [project.testsDir] : testFileGlobs,

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -6,7 +6,6 @@ const os = require('os');
 const path = require('path');
 const which = require('which');
 const packageInfo = require('../package.json');
-const { DependencyProvider } = require('./DependencyProvider.js');
 const ElmJson = require('./ElmJson');
 const Install = require('./Install');
 const Project = require('./Project');
@@ -95,8 +94,6 @@ elm-test "src/**/*Tests.elm"
 `.trim();
 
 function main() {
-  const dependencyProvider = new DependencyProvider();
-
   process.title = 'elm-test';
 
   program
@@ -222,6 +219,9 @@ function main() {
         const Generate = require('./Generate');
         const FindTests = require('./FindTests');
         const Compile = require('./Compile');
+        const { DependencyProvider } = require('./DependencyProvider.js');
+        const dependencyProvider = new DependencyProvider();
+
         Generate.generateElmJson(dependencyProvider, project);
         await Compile.compileSources(
           FindTests.resolveGlobs(
@@ -252,6 +252,8 @@ function main() {
       const projectRootDir = getProjectRootDir('tests');
       const processes = Math.max(1, os.cpus().length);
       const RunTests = require('./RunTests');
+      const { DependencyProvider } = require('./DependencyProvider.js');
+      const dependencyProvider = new DependencyProvider();
       RunTests.runTests(
         dependencyProvider,
         projectRootDir,

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -6,7 +6,6 @@ const os = require('os');
 const path = require('path');
 const packageInfo = require('../package.json');
 const ElmJson = require('./ElmJson');
-const Project = require('./Project');
 const Report = require('./Report');
 
 void Report;
@@ -48,7 +47,8 @@ function getProjectRootDir(subcommand /*: string */) /*: string */ {
   return path.dirname(elmJsonPath);
 }
 
-function getProject(subcommand /*: string */) /*: typeof Project.Project */ {
+function getProject(subcommand /*: string */) {
+  const Project = require('./Project');
   try {
     return Project.init(getProjectRootDir(subcommand), packageInfo.version);
   } catch (error) {

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -9,7 +9,6 @@ const packageInfo = require('../package.json');
 const Compile = require('./Compile');
 const { DependencyProvider } = require('./DependencyProvider.js');
 const ElmJson = require('./ElmJson');
-const Generate = require('./Generate');
 const Install = require('./Install');
 const Project = require('./Project');
 const Report = require('./Report');
@@ -222,8 +221,9 @@ function main() {
       const pathToElmBinary = getPathToElmBinary(options.compiler);
       const project = getProject('make');
       const make = async () => {
-        Generate.generateElmJson(dependencyProvider, project);
+        const Generate = require('./Generate');
         const FindTests = require('./FindTests');
+        Generate.generateElmJson(dependencyProvider, project);
         await Compile.compileSources(
           FindTests.resolveGlobs(
             testFileGlobs.length === 0 ? [project.testsDir] : testFileGlobs,

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -12,7 +12,6 @@ const ElmJson = require('./ElmJson');
 const Install = require('./Install');
 const Project = require('./Project');
 const Report = require('./Report');
-const RunTests = require('./RunTests');
 
 void Report;
 
@@ -252,6 +251,7 @@ function main() {
       const pathToElmBinary = getPathToElmBinary(options.compiler);
       const projectRootDir = getProjectRootDir('tests');
       const processes = Math.max(1, os.cpus().length);
+      const RunTests = require('./RunTests');
       RunTests.runTests(
         dependencyProvider,
         projectRootDir,

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -6,7 +6,6 @@ const os = require('os');
 const path = require('path');
 const which = require('which');
 const packageInfo = require('../package.json');
-const Compile = require('./Compile');
 const { DependencyProvider } = require('./DependencyProvider.js');
 const ElmJson = require('./ElmJson');
 const Install = require('./Install');
@@ -222,6 +221,7 @@ function main() {
       const make = async () => {
         const Generate = require('./Generate');
         const FindTests = require('./FindTests');
+        const Compile = require('./Compile');
         Generate.generateElmJson(dependencyProvider, project);
         await Compile.compileSources(
           FindTests.resolveGlobs(

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -1,7 +1,6 @@
 // @flow
 
 const { InvalidOptionArgumentError, Option, program } = require('commander');
-const fs = require('fs');
 const path = require('path');
 const packageInfo = require('../package.json');
 
@@ -21,6 +20,7 @@ const parsePositiveInteger =
   };
 
 function findClosestElmJson(dir /*: string */) /*: string | void */ {
+  const fs = require('fs');
   const ElmJson = require('./ElmJson');
   do {
     const entry = ElmJson.getPath(dir);
@@ -158,6 +158,7 @@ function main() {
     .command('init')
     .description('Install elm-explorations/test and create tests/Example.elm')
     .action(() => {
+      const fs = require('fs');
       const Install = require('./Install');
 
       const options = program.opts();

--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -2,7 +2,6 @@
 
 const { InvalidOptionArgumentError, Option, program } = require('commander');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 const packageInfo = require('../package.json');
 
@@ -245,12 +244,14 @@ function main() {
     // command and only run tests in `src/`, ignoring all files in `tests/`.
     .command('__elmTestCommand__ [globs...]', { hidden: true, isDefault: true })
     .action((testFileGlobs) => {
+      const os = require('os');
+      const RunTests = require('./RunTests');
+      const { DependencyProvider } = require('./DependencyProvider.js');
+
       const options = program.opts();
       const pathToElmBinary = getPathToElmBinary(options.compiler);
       const projectRootDir = getProjectRootDir('tests');
       const processes = Math.max(1, os.cpus().length);
-      const RunTests = require('./RunTests');
-      const { DependencyProvider } = require('./DependencyProvider.js');
       const dependencyProvider = new DependencyProvider();
       RunTests.runTests(
         dependencyProvider,


### PR DESCRIPTION
1. Imports modules only when they're requested. There may be more imports for which we could do this
2. Use while loop in `findClosedElmJson`, as recursion in JS is not optimal.
3. Reduce the number of operations when using `--report=json` or `--report=junit`.

This makes the startup time faster, as demonstrated when running using `--help` (using `hyperfine`):

```
Benchmark 1: master
  Time (mean ± σ):      94.2 ms ±   1.3 ms    [User: 105.0 ms, System: 16.5 ms]
  Range (min … max):    91.7 ms …  97.2 ms    31 runs
 
Benchmark 2: branch
  Time (mean ± σ):      35.9 ms ±   1.0 ms    [User: 31.1 ms, System: 8.2 ms]
  Range (min … max):    34.8 ms …  41.9 ms    80 runs
 
Summary
  branch ran 2.63 ± 0.08 times faster than master
```

However, when running regular tests (plain `elm-test`, on `elmcraft/core-extra`), I'm getting worse results:

```elm
Benchmark 1: master
  Time (mean ± σ):      1.634 s ±  0.068 s    [User: 0.633 s, System: 0.218 s]
  Range (min … max):    1.510 s …  1.722 s    10 runs
 
Benchmark 2: branch
  Time (mean ± σ):      1.991 s ±  0.413 s    [User: 0.628 s, System: 0.232 s]
  Range (min … max):    1.644 s …  2.745 s    10 runs
 
Summary
  master ran 1.22 ± 0.26 times faster than branch
```

I don't know if my benchmarking is wrong or if lazy imports makes things worse when they're spread out and most of them end up being called. If I end up running `hyperfine` with benchmarks reversed, I usually get diverging results :/ 
However, `mocha` tests reports the duration of slow tests, and when comparing `mocha tests` on both branches, the new version does seem to yield faster tests.