### PR TITLE
Lazy load xmlbuilder and chokidar

### DIFF
--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -1,7 +1,6 @@
 // @flow
 
 const chalk = require('./chalk');
-const chokidar = require('chokidar');
 const path = require('path');
 const readline = require('readline');
 const packageInfo = require('../package.json');
@@ -301,7 +300,9 @@ function runTests(
       }
     };
 
-    watcher = chokidar.watch(alwaysWatched, {
+    // chokidar takes 10–20 ms to load, and is only needed
+    // in watch mode, so `require` it late.
+    watcher = require('chokidar').watch(alwaysWatched, {
       ignoreInitial: true,
       ignored: FindTests.ignoredDirsGlobs,
       disableGlobbing: true,

--- a/lib/Supervisor.js
+++ b/lib/Supervisor.js
@@ -5,7 +5,6 @@ const child_process = require('child_process');
 const fs = require('fs');
 const net = require('net');
 const split = require('split');
-const XmlBuilder = require('xmlbuilder');
 const Report = require('./Report');
 
 function run(
@@ -218,9 +217,13 @@ function run(
                 };
 
                 console.log(
-                  XmlBuilder.create(xml, {
-                    invalidCharReplacement: invalidCharReplacement,
-                  }).end()
+                  // xmlbuilder takes 10–20 ms to load, and is only needed
+                  // when using the junit report, so `require` it late.
+                  require('xmlbuilder')
+                    .create(xml, {
+                      invalidCharReplacement: invalidCharReplacement,
+                    })
+                    .end()
                 );
               }
             }


### PR DESCRIPTION
Inspired by https://github.com/rtfeldman/node-test-runner/pull/658

xmlbuilder and chokidar take 10–20 ms each to load, while most core modules take less than 1 ms. Those two are only used in specific cases: junit report, and watch mode. Lazy loading those is very simple and gives a tiny performance boost to all use cases where they are not needed.