### PR TITLE
Simplify by requiring a single expectation

### DIFF
--- a/elm/src/Test/Reporter/TestResults.elm
+++ b/elm/src/Test/Reporter/TestResults.elm
@@ -4,7 +4,7 @@ module Test.Reporter.TestResults exposing
     , SummaryInfo
     , TestResult
     , isFailure
-    , outcomesFromExpectations
+    , outcomeFromExpectations
     )
 
 import Expect exposing (Expectation)
@@ -52,75 +52,26 @@ isFailure outcome =
             False
 
 
-outcomesFromExpectations : List Expectation -> List Outcome
-outcomesFromExpectations expectations =
+outcomeFromExpectations : List Expectation -> Outcome
+outcomeFromExpectations expectations =
     case expectations of
-        expectation :: [] ->
-            -- Most often we'll get exactly 1 pass, so try that case first!
+        -- The type of test runner functions says that they return `List Expectation`,
+        -- but in practice they only ever return lists with exactly one item:
+        -- https://github.com/elm-explorations/test/pull/244
+        -- That PR was reverted because it unfortunately was a breaking change for the package:
+        -- https://github.com/elm-explorations/test/commit/11f70d5fc0b6fdc88d7a34ea1d10f56969890493
+        -- But to keep things simpler here, we only support exactly one expectation.
+        [ expectation ] ->
             case Test.Runner.getFailureReason expectation of
                 Nothing ->
-                    [ Passed (Test.Runner.getDistributionReport expectation) ]
+                    Passed (Test.Runner.getDistributionReport expectation)
 
                 Just failure ->
                     if Test.Runner.isTodo expectation then
-                        [ Todo failure.description ]
+                        Todo failure.description
 
                     else
-                        [ Failed
-                            [ ( failure, Test.Runner.getDistributionReport expectation ) ]
-                        ]
+                        Failed [ ( failure, Test.Runner.getDistributionReport expectation ) ]
 
-        _ :: _ ->
-            let
-                builder =
-                    List.foldl outcomesFromExpectationsHelp
-                        { passes = [], todos = [], failures = [] }
-                        expectations
-
-                failuresList =
-                    case builder.failures of
-                        [] ->
-                            []
-
-                        failures ->
-                            [ Failed failures ]
-            in
-            List.concat
-                [ List.map Passed builder.passes
-                , List.map Todo builder.todos
-                , failuresList
-                ]
-
-        [] ->
-            []
-
-
-type alias OutcomeBuilder =
-    { passes : List DistributionReport
-    , todos : List String
-    , failures : List ( Failure, DistributionReport )
-    }
-
-
-outcomesFromExpectationsHelp : Expectation -> OutcomeBuilder -> OutcomeBuilder
-outcomesFromExpectationsHelp expectation builder =
-    case Test.Runner.getFailureReason expectation of
-        Just failure ->
-            if Test.Runner.isTodo expectation then
-                { builder | todos = failure.description :: builder.todos }
-
-            else
-                { builder
-                    | failures =
-                        ( failure
-                        , Test.Runner.getDistributionReport expectation
-                        )
-                            :: builder.failures
-                }
-
-        Nothing ->
-            { builder
-                | passes =
-                    Test.Runner.getDistributionReport expectation
-                        :: builder.passes
-            }
+        _ ->
+            Debug.todo ("A test somehow did not return exactly 1 expectation, it returned " ++ String.fromInt (List.length expectations) ++ "!")

--- a/elm/src/Test/Runner/Node.elm
+++ b/elm/src/Test/Runner/Node.elm
@@ -20,7 +20,7 @@ import Random
 import Task
 import Test exposing (Test)
 import Test.Reporter.Reporter exposing (Report, RunInfo, TestReporter, createReporter)
-import Test.Reporter.TestResults exposing (Outcome, TestResult, isFailure, outcomesFromExpectations)
+import Test.Reporter.TestResults exposing (Outcome, TestResult, isFailure, outcomeFromExpectations)
 import Test.Runner exposing (Runner, SeededRunners(..))
 import Test.Runner.JsMessage as JsMessage exposing (JsMessage(..))
 import Time exposing (Posix)
@@ -75,7 +75,7 @@ type alias TestProgram =
 type Msg
     = Receive Decode.Value
     | Dispatch Posix
-    | Complete (List String) (List Outcome) Posix Posix
+    | Complete (List String) Outcome Posix Posix
 
 
 {-| The port names are prefixed to reduce the likelihood of the project
@@ -96,11 +96,11 @@ dispatch model startTime =
 
         Just config ->
             let
-                outcomes =
-                    outcomesFromExpectations (config.run ())
+                outcome =
+                    outcomeFromExpectations (config.run ())
             in
             Time.now
-                |> Task.perform (Complete config.labels outcomes startTime)
+                |> Task.perform (Complete config.labels outcome startTime)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -173,19 +173,16 @@ update msg ({ testReporter } as model) =
         Dispatch startTime ->
             ( model, dispatch model startTime )
 
-        Complete labels outcomes startTime endTime ->
+        Complete labels outcome startTime endTime ->
             let
                 duration =
                     Time.posixToMillis endTime - Time.posixToMillis startTime
 
-                prependOutcome outcome rest =
+                results =
                     ( model.nextTestToRun
                     , { labels = labels, outcome = outcome, duration = duration }
                     )
-                        :: rest
-
-                results =
-                    List.foldl prependOutcome model.results outcomes
+                        :: model.results
 
                 nextTestToRun =
                     model.nextTestToRun + model.processes
@@ -193,7 +190,7 @@ update msg ({ testReporter } as model) =
                 isFinished =
                     nextTestToRun >= model.runInfo.testCount
             in
-            if isFinished || List.any isFailure outcomes then
+            if isFinished || isFailure outcome then
                 let
                     cmd =
                         sendResults isFinished testReporter results


### PR DESCRIPTION
The code partially supported test runner functions returning more than one expectation, which means more than one outcome of each test. But what does it mean to have multiple outcomes for a single test? How can it both pass and fail at the same time? Anyways, at the end we encoded the outcomes into a JSON object keyed by test ID. Duplicate keys in JSON are dropped when parsed, so we threw away all but one outcome.

Turns out test runner functions always return a list with exactly one expectation in practice: https://github.com/elm-explorations/test/pull/244 (reverted because it unfortunately was a breaking change for the package: https://github.com/elm-explorations/test/commit/11f70d5fc0b6fdc88d7a34ea1d10f56969890493)

This PR simplifies by failing if a test somehow does not return exactly one expectation.