### PR TITLE
Replace `split` dependency with built-in `readline`

### DIFF
--- a/lib/Supervisor.js
+++ b/lib/Supervisor.js
@@ -2,7 +2,7 @@ const chalk = require('./chalk');
 const child_process = require('child_process');
 const fs = require('fs');
 const net = require('net');
-const split = require('split');
+const readline = require('readline');
 const Report = require('./Report');
 const XMLBuilder = require('./XMLBuilder');
 
@@ -165,15 +165,13 @@ function run(elmTestVersion, pipeFilename, report, processes, dest, watch) {
 
       // See the long note near client.write() in worker.js for why we do this.
       // It fixes a nasty bug!
-      var stream = socket.pipe(split());
+      // https://nodejs.org/api/readline.html#example-read-file-stream-line-by-line
+      var stream = readline.createInterface({
+        input: socket,
+        crlfDelay: Infinity,
+      });
 
-      stream.on('data', function (data) {
-        // In watch mode, the socket is drained which results in an extraneous
-        // message being sent. If we receive no data, ignore it.
-        if (!data) {
-          return;
-        }
-
+      stream.on('line', function (data) {
         var response = JSON.parse(data);
 
         switch (response.type) {
@@ -183,7 +181,7 @@ function run(elmTestVersion, pipeFilename, report, processes, dest, watch) {
             // This worker found no tests remaining to run; it's finished!
             finishedWorkers++;
 
-            // If all the workers have finished, print the summmary.
+            // If all the workers have finished, print the summary.
             if (finishedWorkers === workers.length) {
               socket.write(
                 JSON.stringify({
@@ -255,8 +253,12 @@ function run(elmTestVersion, pipeFilename, report, processes, dest, watch) {
       });
     }
 
-    var pendingException = false,
-      server = net.createServer(initWorker);
+    var pendingException = false;
+
+    // Using a named pipe to communicate is actually faster than
+    // using `process.send` or `worker_threads`! See:
+    // https://github.com/rtfeldman/node-test-runner/pull/674
+    var server = net.createServer(initWorker);
 
     server.on('error', function (err) {
       console.error(err.stack);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "chokidar": "^3.5.3",
         "commander": "^9.4.1",
         "elm-solve-deps-wasm": "^1.0.2 || ^2.0.0",
-        "split": "^1.0.1",
         "tinyglobby": "^0.2.10",
         "which": "^2.0.2"
       },
@@ -23,7 +22,6 @@
         "@eslint/js": "9.20.0",
         "@types/mocha": "10.0.10",
         "@types/node": "26.0.1",
-        "@types/split": "1.0.5",
         "@types/which": "3.0.4",
         "elm-review": "2.13.1",
         "elm-tooling": "1.18.0",
@@ -443,27 +441,6 @@
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/split": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/split/-/split-1.0.5.tgz",
-      "integrity": "sha512-gMiDr4vA6YofTpAkPQtP+5pvStIf3CMYphf32YAG/3RwogNL8ii1CQKDc+sxN62KuxPoRaJXcf2zDCDkEBH4FA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/through": "*"
-      }
-    },
-    "node_modules/@types/through": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
-      "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2845,17 +2822,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2998,11 +2964,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.10",
@@ -3535,25 +3496,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/split": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/split/-/split-1.0.5.tgz",
-      "integrity": "sha512-gMiDr4vA6YofTpAkPQtP+5pvStIf3CMYphf32YAG/3RwogNL8ii1CQKDc+sxN62KuxPoRaJXcf2zDCDkEBH4FA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/through": "*"
-      }
-    },
-    "@types/through": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
-      "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -5110,14 +5052,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "requires": {
-        "through": "2"
-      }
-    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5223,11 +5157,6 @@
         "ansi-escapes": "^4.2.1",
         "supports-hyperlinks": "^2.0.0"
       }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tinyglobby": {
       "version": "0.2.10",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "chokidar": "^3.5.3",
     "commander": "^9.4.1",
     "elm-solve-deps-wasm": "^1.0.2 || ^2.0.0",
-    "split": "^1.0.1",
     "tinyglobby": "^0.2.10",
     "which": "^2.0.2"
   },
@@ -53,7 +52,6 @@
     "@eslint/js": "9.20.0",
     "@types/mocha": "10.0.10",
     "@types/node": "26.0.1",
-    "@types/split": "1.0.5",
     "@types/which": "3.0.4",
     "elm-review": "2.13.1",
     "elm-tooling": "1.18.0",


### PR DESCRIPTION
We use a dependency called [split](https://github.com/dominictarr/split) for reading data line by line. That repo for that dependency has been marked as archived. Node.js’ built-in `readline` module can do reading line by line, too, so this PR switches to that. One dependency less. I have verified with the benchmark in https://github.com/rtfeldman/node-test-runner/pull/674 that this is as fast as before.