### PR TITLE
Fix problems with watch mode with --workers=1

### DIFF
--- a/lib/Generate.js
+++ b/lib/Generate.js
@@ -23,10 +23,10 @@ function prepareCompiledJsFile(pipeFilename, dest) {
   const content = fs.readFileSync(dest, 'utf8');
   const finalContent = `
 ${before}
-var Elm = (function(module) {
+var Elm = (function() {
 ${patch(content)}
 return this.Elm;
-})({});
+}).call({});
 var pipeFilename = ${JSON.stringify(pipeFilename)};
 ${after}
   `.trim();

--- a/lib/Supervisor.js
+++ b/lib/Supervisor.js
@@ -272,6 +272,8 @@ function run(elmTestVersion, pipeFilename, report, processes, dest, watch) {
     // If just one process, run single-threaded.
     if (processes === 1) {
       var { run } = require(dest);
+      // Allow the generated file to be `require`d again (for watch mode).
+      delete require.cache[dest];
       var send = run(
         0,
         /** @type { (response: any) => void } */

--- a/templates/after.js
+++ b/templates/after.js
@@ -1,5 +1,7 @@
 function run(index, receive) {
   var app = Elm.Test.Generated.Main.init({ flags: index });
+  // Without this, each run leaks memory in single-threaded mode:
+  Elm = null;
   app.ports.elmTestPort__send.subscribe(receive);
   return app.ports.elmTestPort__receive.send;
 }


### PR DESCRIPTION
Followup on #680.

There were a couple of problems with single-threaded watch mode (`--workers=1 --watch`):

1. If you made changes to Elm files, the tests were re-run, but with the _old_ code. Fixed by clearing the `require` cache.
2. When the above was fixed, loading the new code resulted in an error due to the IIFE wrapper around Elm’s JS in `before.js` was wrong.
3. When the above was fixed, I noticed that we leaked memory each run.

To measure memory usage, I used the following patch:

```patch
diff --git a/elm/src/Test/Runner/Node.elm b/elm/src/Test/Runner/Node.elm
index 679d7e3..5bb4b09 100644
--- a/elm/src/Test/Runner/Node.elm
+++ b/elm/src/Test/Runner/Node.elm
@@ -63,9 +63,22 @@ type alias Model =
     , processes : Int
     , nextTestToRun : TestId
     , autoFail : Maybe String
+    , heavy : List Heavy
     }
 
 
+type alias Heavy =
+    { name : String
+    , hydrospanner : Int
+    , falcon : Falcon
+    , ints : List Int
+    }
+
+
+type Falcon
+    = Millenium Float
+
+
 {-| A program which will run tests and report their results.
 -}
 type alias TestProgram =
@@ -245,6 +258,19 @@ sendBegin model =
         |> elmTestPort__send
 
 
+heavy : List Heavy
+heavy =
+    List.range 0 1000
+        |> List.map
+            (\i ->
+                { name = String.fromInt i
+                , hydrospanner = i ^ 2
+                , falcon = Millenium (toFloat i * pi)
+                , ints = List.range 0 i
+                }
+            )
+
+
 init : InitArgs -> Int -> ( Model, Cmd Msg )
 init { processes, globs, paths, fuzzRuns, initialSeed, report, runners } index =
     let
@@ -290,6 +316,7 @@ init { processes, globs, paths, fuzzRuns, initialSeed, report, runners } index =
             , results = []
             , testReporter = testReporter
             , autoFail = autoFail
+            , heavy = heavy
             }
 
         cmd =
@@ -324,6 +351,7 @@ failInit message report _ =
             , results = []
             , testReporter = createReporter report
             , autoFail = Nothing
+            , heavy = heavy
             }
 
         cmd =
diff --git a/lib/RunTests.js b/lib/RunTests.js
index 7da7be8..9454c19 100644
--- a/lib/RunTests.js
+++ b/lib/RunTests.js
@@ -297,6 +297,7 @@ function runTests(
         if (!Report.isMachineReadable(report)) {
           console.log(chalk.blue('Watching for changes...'));
         }
+        global.gc();
         currentRun = undefined;
       }
     };
@@ -352,7 +353,15 @@ function runTests(
     // It’s unclear when this event occurrs.
     watcher.on('error', (error) => console.error('Watcher error:', error));
 
-    currentRun = run().then(onRunFinish);
+    currentRun = run()
+      .then(onRunFinish)
+      .then(() => {
+        setInterval(() => {
+          process.stdout.write(
+            ` ${(process.memoryUsage().heapUsed / (1024 * 1024)).toFixed(2)}\r`
+          );
+        }, 1000);
+      });
 
     // A promise that never resolves. We’ll watch until killed.
     return new Promise(() => {});
```

It puts a ~30 MB object in the Elm model. This makes it easy to see if the memory usage is growing with each run.

After each run I force garbage collection. (Requires `--expose-gc`.) Every second I measure used heap space.

Before, the memory usage increased with ~30 MB per run. After, the memory usage is unchanged after each run.

Run it like so:

```
cd example-application
node --expose-gc ../bin/elm-test --seed 0 --workers 1 --watch
```

Then make a change to one of the test files (or `touch` it) to trigger new runs.